### PR TITLE
Allow copying File Options Again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "zip_next"
 version = "1.0.1"
-authors = ["Mathijs van de Nes <git@mathijs.vd-nes.nl>", "Marli Frost <marli@frost.red>", "Ryan Levick <ryan.levick@gmail.com>",
-"Chris Hennick <hennickc@amazon.com>"]
+authors = [
+    "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
+    "Marli Frost <marli@frost.red>",
+    "Ryan Levick <ryan.levick@gmail.com>",
+    "Chris Hennick <hennickc@amazon.com>",
+]
 license = "MIT"
 repository = "https://github.com/Pr0methean/zip-next.git"
 keywords = ["zip", "archive"]
@@ -22,9 +26,11 @@ constant_time_eq = { version = "0.3.0", optional = true }
 crc32fast = "1.4.0"
 flate2 = { version = "1.0.28", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
-pbkdf2 = {version = "0.12.2", optional = true }
-sha1 = {version = "0.10.6", optional = true }
-time = { version = "0.3.34", optional = true, default-features = false, features = ["std"] }
+pbkdf2 = { version = "0.12.2", optional = true }
+sha1 = { version = "0.10.6", optional = true }
+time = { version = "0.3.34", optional = true, default-features = false, features = [
+    "std",
+] }
 zstd = { version = "0.13.1", optional = true, default-features = false }
 zopfli = { version = "0.8.0", optional = true }
 deflate64 = { version = "0.1.8", optional = true }
@@ -41,9 +47,9 @@ bencher = "0.1.5"
 getrandom = { version = "0.2.14", features = ["js"] }
 walkdir = "2.5.0"
 time = { version = "0.3.34", features = ["formatting", "macros"] }
-
+anyhow = "1"
 [features]
-aes-crypto = [ "aes", "constant_time_eq", "hmac", "pbkdf2", "sha1" ]
+aes-crypto = ["aes", "constant_time_eq", "hmac", "pbkdf2", "sha1"]
 chrono = ["chrono/default"]
 deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
@@ -52,7 +58,17 @@ deflate-zlib-ng = ["flate2/zlib-ng"]
 deflate-zopfli = ["zopfli"]
 lzma = ["lzma-rs/stream"]
 unreserved = []
-default = ["aes-crypto", "bzip2", "deflate", "deflate64", "deflate-zlib-ng", "deflate-zopfli", "lzma", "time", "zstd"]
+default = [
+    "aes-crypto",
+    "bzip2",
+    "deflate",
+    "deflate64",
+    "deflate-zlib-ng",
+    "deflate-zopfli",
+    "lzma",
+    "time",
+    "zstd",
+]
 
 [[bench]]
 name = "read_entry"

--- a/benches/read_entry.rs
+++ b/benches/read_entry.rs
@@ -4,13 +4,13 @@ use std::io::{Cursor, Read, Write};
 
 use bencher::Bencher;
 use getrandom::getrandom;
-use zip_next::{ZipArchive, ZipWriter};
+use zip_next::{write::SimpleFileOptions, ZipArchive, ZipWriter};
 
 fn generate_random_archive(size: usize) -> Vec<u8> {
     let data = Vec::new();
     let mut writer = ZipWriter::new(Cursor::new(data));
-    let options = zip_next::write::FileOptions::default()
-        .compression_method(zip_next::CompressionMethod::Stored);
+    let options =
+        SimpleFileOptions::default().compression_method(zip_next::CompressionMethod::Stored);
 
     writer.start_file("random.dat", options).unwrap();
     let mut bytes = vec![0u8; size];

--- a/benches/read_metadata.rs
+++ b/benches/read_metadata.rs
@@ -3,7 +3,7 @@ use bencher::{benchmark_group, benchmark_main};
 use std::io::{Cursor, Write};
 
 use bencher::Bencher;
-use zip_next::write::FileOptions;
+use zip_next::write::SimpleFileOptions;
 use zip_next::{CompressionMethod, ZipArchive, ZipWriter};
 
 const FILE_COUNT: usize = 15_000;
@@ -12,13 +12,13 @@ const FILE_SIZE: usize = 1024;
 fn generate_random_archive(count_files: usize, file_size: usize) -> Vec<u8> {
     let data = Vec::new();
     let mut writer = ZipWriter::new(Cursor::new(data));
-    let options = FileOptions::default().compression_method(CompressionMethod::Stored);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
     let bytes = vec![0u8; file_size];
 
     for i in 0..count_files {
         let name = format!("file_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef_{i}.dat");
-        writer.start_file(name, options.clone()).unwrap();
+        writer.start_file(name, options).unwrap();
         writer.write_all(&bytes).unwrap();
     }
 

--- a/examples/write_sample.rs
+++ b/examples/write_sample.rs
@@ -1,5 +1,5 @@
 use std::io::prelude::*;
-use zip_next::write::FileOptions;
+use zip_next::write::SimpleFileOptions;
 
 fn main() {
     std::process::exit(real_main());
@@ -27,15 +27,15 @@ fn doit(filename: &str) -> zip_next::result::ZipResult<()> {
 
     let mut zip = zip_next::ZipWriter::new(file);
 
-    zip.add_directory("test/", Default::default())?;
+    zip.add_directory("test/", SimpleFileOptions::default())?;
 
-    let options = FileOptions::default()
+    let options = SimpleFileOptions::default()
         .compression_method(zip_next::CompressionMethod::Stored)
         .unix_permissions(0o755);
     zip.start_file("test/☃.txt", options)?;
     zip.write_all(b"Hello, World!\n")?;
 
-    zip.start_file("test/lorem_ipsum.txt", Default::default())?;
+    zip.start_file("test/lorem_ipsum.txt", options)?;
     zip.write_all(LOREM_IPSUM)?;
 
     zip.finish()?;

--- a/fuzz/fuzz_targets/fuzz_write.rs
+++ b/fuzz/fuzz_targets/fuzz_write.rs
@@ -1,27 +1,27 @@
 #![no_main]
 
-use std::cell::RefCell;
-use libfuzzer_sys::fuzz_target;
 use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::cell::RefCell;
 use std::io::{Cursor, Read, Seek, Write};
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
-#[derive(Arbitrary,Clone,Debug)]
+#[derive(Arbitrary, Clone, Debug)]
 pub enum BasicFileOperation {
     WriteNormalFile {
         contents: Vec<Vec<u8>>,
-        options: zip_next::write::FileOptions,
+        options: zip_next::write::FullFileOptions,
     },
-    WriteDirectory(zip_next::write::FileOptions),
+    WriteDirectory(zip_next::write::FullFileOptions),
     WriteSymlinkWithTarget {
         target: Box<PathBuf>,
-        options: zip_next::write::FileOptions,
+        options: zip_next::write::FullFileOptions,
     },
     ShallowCopy(Box<FileOperation>),
     DeepCopy(Box<FileOperation>),
 }
 
-#[derive(Arbitrary,Clone,Debug)]
+#[derive(Arbitrary, Clone, Debug)]
 pub struct FileOperation {
     basic: BasicFileOperation,
     name: String,
@@ -29,7 +29,7 @@ pub struct FileOperation {
     // 'abort' flag is separate, to prevent trying to copy an aborted file
 }
 
-#[derive(Arbitrary,Clone,Debug)]
+#[derive(Arbitrary, Clone, Debug)]
 pub struct FuzzTestCase {
     comment: Vec<u8>,
     operations: Vec<(FileOperation, bool)>,
@@ -47,14 +47,25 @@ impl FileOperation {
     }
 }
 
-fn do_operation<T>(writer: &mut RefCell<zip_next::ZipWriter<T>>,
-                   operation: FileOperation,
-                   abort: bool, flush_on_finish_file: bool) -> Result<(), Box<dyn std::error::Error>>
-                   where T: Read + Write + Seek {
-    writer.borrow_mut().set_flush_on_finish_file(flush_on_finish_file);
+fn do_operation<T>(
+    writer: &mut RefCell<zip_next::ZipWriter<T>>,
+    operation: FileOperation,
+    abort: bool,
+    flush_on_finish_file: bool,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: Read + Write + Seek,
+{
+    writer
+        .borrow_mut()
+        .set_flush_on_finish_file(flush_on_finish_file);
     let name = operation.name;
     match operation.basic {
-        BasicFileOperation::WriteNormalFile {contents, mut options, ..} => {
+        BasicFileOperation::WriteNormalFile {
+            contents,
+            mut options,
+            ..
+        } => {
             let uncompressed_size = contents.iter().map(Vec::len).sum::<usize>();
             if uncompressed_size >= u32::MAX as usize {
                 options = options.large_file(true);
@@ -67,8 +78,10 @@ fn do_operation<T>(writer: &mut RefCell<zip_next::ZipWriter<T>>,
         BasicFileOperation::WriteDirectory(options) => {
             writer.borrow_mut().add_directory(name, options)?;
         }
-        BasicFileOperation::WriteSymlinkWithTarget {target, options} => {
-            writer.borrow_mut().add_symlink(name, target.to_string_lossy(), options)?;
+        BasicFileOperation::WriteSymlinkWithTarget { target, options } => {
+            writer
+                .borrow_mut()
+                .add_symlink(name, target.to_string_lossy(), options)?;
         }
         BasicFileOperation::ShallowCopy(base) => {
             let base_name = base.referenceable_name();
@@ -86,8 +99,8 @@ fn do_operation<T>(writer: &mut RefCell<zip_next::ZipWriter<T>>,
     }
     if operation.reopen {
         let old_comment = writer.borrow().get_raw_comment().to_owned();
-        let new_writer = zip_next::ZipWriter::new_append(
-            writer.borrow_mut().finish().unwrap()).unwrap();
+        let new_writer =
+            zip_next::ZipWriter::new_append(writer.borrow_mut().finish().unwrap()).unwrap();
         assert_eq!(&old_comment, new_writer.get_raw_comment());
         *writer = new_writer.into();
     }
@@ -98,7 +111,12 @@ fuzz_target!(|test_case: FuzzTestCase| {
     let mut writer = RefCell::new(zip_next::ZipWriter::new(Cursor::new(Vec::new())));
     writer.borrow_mut().set_raw_comment(test_case.comment);
     for (operation, abort) in test_case.operations {
-        let _ = do_operation(&mut writer, operation, abort, test_case.flush_on_finish_file);
+        let _ = do_operation(
+            &mut writer,
+            operation,
+            abort,
+            test_case.flush_on_finish_file,
+        );
     }
     let _ = zip_next::ZipArchive::new(writer.borrow_mut().finish().unwrap());
 });

--- a/src/types.rs
+++ b/src/types.rs
@@ -352,9 +352,9 @@ pub struct ZipFileData {
     /// Raw file name. To be used when file_name was incorrectly decoded.
     pub file_name_raw: Box<[u8]>,
     /// Extra field usually used for storage expansion
-    pub extra_field: Arc<Vec<u8>>,
+    pub extra_field: Option<Arc<Vec<u8>>>,
     /// Extra field only written to central directory
-    pub central_extra_field: Arc<Vec<u8>>,
+    pub central_extra_field: Option<Arc<Vec<u8>>>,
     /// File comment
     pub file_comment: Box<str>,
     /// Specifies where the local header of the file starts
@@ -458,6 +458,20 @@ impl ZipFileData {
             _ => 20,
         }
     }
+    #[inline(always)]
+    pub(crate) fn extra_field_len(&self) -> usize {
+        self.extra_field
+            .as_ref()
+            .map(|v| v.len())
+            .unwrap_or_default()
+    }
+    #[inline(always)]
+    pub(crate) fn central_extra_field_len(&self) -> usize {
+        self.central_extra_field
+            .as_ref()
+            .map(|v| v.len())
+            .unwrap_or_default()
+    }
 }
 
 /// The encryption specification used to encrypt a file with AES.
@@ -521,8 +535,8 @@ mod test {
             uncompressed_size: 0,
             file_name: file_name.clone().into_boxed_str(),
             file_name_raw: file_name.into_bytes().into_boxed_slice(),
-            extra_field: Arc::new(vec![]),
-            central_extra_field: Arc::new(vec![]),
+            extra_field: None,
+            central_extra_field: None,
             file_comment: String::with_capacity(0).into_boxed_str(),
             header_start: 0,
             data_start: OnceLock::new(),

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -4,7 +4,7 @@ pub mod stream {
 }
 /// Types for creating ZIP archives.
 pub mod write {
-    use crate::write::FileOptions;
+    use crate::write::{FileOptionExtension, FileOptions};
     /// Unstable methods for [`FileOptions`].
     pub trait FileOptionsExt {
         /// Write the file with the given password using the deprecated ZipCrypto algorithm.
@@ -12,7 +12,7 @@ pub mod write {
         /// This is not recommended for new archives, as ZipCrypto is not secure.
         fn with_deprecated_encryption(self, password: &[u8]) -> Self;
     }
-    impl FileOptionsExt for FileOptions {
+    impl<T: FileOptionExtension> FileOptionsExt for FileOptions<T> {
         fn with_deprecated_encryption(self, password: &[u8]) -> Self {
             self.with_deprecated_encryption(password)
         }

--- a/tests/zip_crypto.rs
+++ b/tests/zip_crypto.rs
@@ -29,7 +29,7 @@ fn encrypting_file() {
     archive
         .start_file(
             "name",
-            zip_next::write::FileOptions::default().with_deprecated_encryption(b"password"),
+            zip_next::write::SimpleFileOptions::default().with_deprecated_encryption(b"password"),
         )
         .unwrap();
     archive.write_all(b"test").unwrap();


### PR DESCRIPTION
When `extra_data` and `central_extra_data` were added to FileOptions we lost the ability to implement Copy for FileOptions. 
Plenty of people will want to Zip a basic set of files. But now we have an unnecessary Atomic value being incremented and decremented. Also an empty allocation inside the Vec

So this solution has FileOptions take a Generic Parameter to hold "Extra Options" This can be the Unit type or ExtendedFileOptions

This also puts extra_data and central_extra_data in an Option inside ZipFileData removing the Atomic usage in some cases there too. 


This does break the current code as people will need to specify the generic parameter or change FileOptions to either SimpleFileOptions or  FullFileOptions


I also corrected the write_dir test to remove the deprecated API calls
