### PR TITLE
Atomic Wrapper does not need to be const.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -338,7 +338,7 @@ pub const DEFAULT_VERSION: u8 = 46;
 pub struct AtomicU64(atomic::AtomicU64);
 
 impl AtomicU64 {
-    pub const fn new(v: u64) -> Self {
+    pub fn new(v: u64) -> Self {
         Self(atomic::AtomicU64::new(v))
     }
 


### PR DESCRIPTION
The AtomicU64::new function cannot be const on these systems.
```
#[cfg(not(any(
    all(target_arch = "arm", target_pointer_width = "32"),
    target_arch = "mips",
    target_arch = "powerpc"
)))]
```
 So the wrapper type cannot be made const. 
 
 But it wasn't used in a const context. So it was removed. 