### PR TITLE
Automatically approve my own PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,17 +10,23 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and test
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable, '1.70', nightly]
-
+        rustalias: [stable, nightly, msrv]
+        include:
+        - rustalias: stable
+          rust: stable
+        - rustalias: msrv
+          rust: '1.70'
+        - rustalias: nightly
+          rust: nightly
+    name: 'Build and test: ${{ matrix.os }}, ${{ matrix.rustalias }}'
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master
 
-    - name: Install ${{ matrix.rust }}
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}

--- a/.github/workflows/dependabot_automation.yml
+++ b/.github/workflows/dependabot_automation.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-approve and auto-merge
+name: Auto-approve and auto-merge owner-written and Dependabot PRs
 on: pull_request
 
 permissions:
@@ -8,10 +8,11 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'Pr0methean' }}
     steps:
       - name: Dependabot metadata
         id: metadata
+        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: dependabot/fetch-metadata@v2.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This change allows me to submit future changes as PRs that will be auto-approved, rather than as direct pushes to master that would require other open PRs to be rebased.