### PR TITLE
docs: Update zip_writer documentation example

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -143,7 +143,7 @@ pub(crate) mod zip_writer {
     /// use std::io::Write;
     /// use zip::write::SimpleFileOptions;
     ///
-    /// We use a cursor + vec here, though you'd normally use a `File`
+    /// // We use a cursor + vec here, though you'd normally use a `File`
     /// let mut cur = std::io::Cursor::new(Vec::new());
     /// let mut zip = ZipWriter::new(&mut cur);
     ///


### PR DESCRIPTION
Replace the fixed size buffer example with a dynamic Vec

Since the buffer size was of fixed, size, the resulting zip file was always the same size, defeating the purpose of compression

fixes #430 
