### PR TITLE
deps: Bump lzma-rust2 to v0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ zeroize = { version = "1.8", optional = true, features = ["zeroize_derive"] }
 zstd = { version = "0.13", optional = true, default-features = false }
 zopfli = { version = "0.8", optional = true }
 deflate64 = { version = "0.1.9", optional = true }
-lzma-rust2 = { version = "0.13", optional = true, default-features = false, features = ["std", "encoder", "optimization", "xz"] }
-bitstream-io =  { version = "4.5.0", optional = true }
+lzma-rust2 = { version = "0.15", optional = true, default-features = false, features = ["std", "encoder", "optimization", "xz"] }
+bitstream-io = { version = "4.5.0", optional = true }
 
 [target.'cfg(fuzzing)'.dependencies]
 arbitrary = { version = "1.4.1", features = ["derive"] }


### PR DESCRIPTION
Nothing user facing should have changed. Mainly bug fixes, chores and changes in the API that the ZIP crate doesn't use.