### PR TITLE
fix: Default "platform" field in zip files should be set to the local platform, rather than always "Unix" (#470)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -716,7 +716,10 @@ impl ZipFileData {
                 // DOS directory bit
                 external_attributes |= 0x10;
             }
-            if options.permissions.is_some_and(|permissions| permissions & 0o444 == 0) {
+            if options
+                .permissions
+                .is_some_and(|permissions| permissions & 0o444 == 0)
+            {
                 // DOS read-only bit
                 external_attributes |= 0x01;
             }
@@ -1318,13 +1321,16 @@ mod test {
         data.system = System::Dos;
         data.external_attributes = (S_IFLNK | 0o777) << 16;
         assert_eq!(data.unix_mode(), Some(S_IFLNK | 0o777));
-        
+
         data.system = System::Unknown;
         assert_eq!(data.unix_mode(), Some(S_IFLNK | 0o777));
 
         data.external_attributes = 0x10; // DOS directory bit
         data.system = System::Dos;
-        assert_eq!(data.unix_mode().unwrap() & 0o170000, crate::types::ffi::S_IFDIR);
+        assert_eq!(
+            data.unix_mode().unwrap() & 0o170000,
+            crate::types::ffi::S_IFDIR
+        );
     }
 
     #[test]

--- a/src/write.rs
+++ b/src/write.rs
@@ -2272,11 +2272,8 @@ mod test {
             .is_err());
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 108);
-        const DOS_DIR_ATTRIBUTES_BYTE: u8 = if cfg!(windows) {
-            0x10
-        } else {
-            0
-        };
+        const DOS_DIR_ATTRIBUTES_BYTE: u8 = if cfg!(windows) { 0x10 } else { 0 };
+        #[rustfmt::skip]
         assert_eq!(
             *result.get_ref(),
             &[
@@ -2306,6 +2303,7 @@ mod test {
             .is_err());
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 112);
+        #[rustfmt::skip]
         assert_eq!(
             *result.get_ref(),
             &[
@@ -2351,6 +2349,7 @@ mod test {
             .is_err());
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 162);
+        #[rustfmt::skip]
         assert_eq!(
             *result.get_ref(),
             &[
@@ -2390,6 +2389,7 @@ mod test {
         let result = writer.finish().unwrap();
 
         assert_eq!(result.get_ref().len(), 153);
+        #[rustfmt::skip]
         assert_eq!(result.get_ref(), &[80, 75, 3, 4, 10, 0, 0, 0, 0, 0, 0, 0, 33, 0, 94, 198, 50,
             12, 39, 0, 0, 0, 39, 0, 0, 0, 8, 0, 0, 0, 109, 105, 109, 101, 116, 121, 112, 101, 97,
             112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 47, 118, 110, 100, 46, 111, 97, 115,
@@ -2446,7 +2446,7 @@ mod test {
         let result = writer.finish().unwrap();
 
         assert_eq!(result.get_ref().len(), 224);
-
+        #[rustfmt::skip]
         assert_eq!(result.get_ref(), &[80, 75, 3, 4, 10, 0, 0, 0, 0, 0, 0, 0, 33, 0, 29, 183, 125,
             75, 16, 0, 0, 0, 16, 0, 0, 0, 4, 0, 0, 0, 214, 208, 206, 196, 101, 110, 99, 111, 100,
             105, 110, 103, 32, 71, 66, 49, 56, 48, 51, 48, 80, 75, 3, 4, 10, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
Fixed the issue where the compression platform was set to Unix in the Windows environment. Now the platform can be automatically set to Dos or Unix based on the specific operating system.

fix https://github.com/zip-rs/zip2/issues/470