### PR TITLE
ci: Enable `workflow_dispatch` for DevSkim

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -18,7 +18,7 @@ on:
     - cron: '39 17 * * *'
   merge_group:
     types: [checks_requested]
-
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
Should fix, or at least let us work around, the issue where https://github.com/zip-rs/zip2/pull/544 is unable to enter the merge queue because DevSkim isn't triggering for it.