### PR TITLE
chore: release v7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.0](https://github.com/zip-rs/zip2/releases/tag/v7.3.0) - 2026-01-25
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- make zip crate safer and more readable ([#536](https://github.com/zip-rs/zip2/pull/536))
+
 ## [7.2.0](https://github.com/zip-rs/zip2/compare/v7.1.0...v7.2.0) - 2026-01-20
 
 ### <!-- 0 -->🚀 Features


### PR DESCRIPTION



## 🤖 New release

* `zip`: 7.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [7.3.0](https://github.com/zip-rs/zip2/releases/tag/v7.3.0) - 2026-01-25

### <!-- 1 -->🐛 Bug Fixes

- make zip crate safer and more readable ([#536](https://github.com/zip-rs/zip2/pull/536))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).