### PR TITLE
test: Remove unnecessary `pub` from a test function

### DIFF
--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 use zip::ZipArchive;
 
 #[test]
-pub fn decompress_xz() {
+fn decompress_xz() {
     let zip_data = include_bytes!("data/xz.zip");
     let mut archive =
         ZipArchive::new(io::Cursor::new(zip_data)).expect("couldn't open test zip file");


### PR DESCRIPTION
_This PR applies 1/2 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._