### PR TITLE
fix: Treat empty ZipCrypto password as "\0" so that key is slightly harder to guess

### DIFF
--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -52,7 +52,6 @@ pub(crate) struct ZipCryptoKeys {
 }
 
 impl Debug for ZipCryptoKeys {
-    #[allow(unreachable_code)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         cfg_if_expr! {
             #[cfg(any(test, fuzzing))] => {


### PR DESCRIPTION
_This PR applies 3/5 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._