### PR TITLE
chore: release v7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.0](https://github.com/zip-rs/zip2/compare/v7.3.0-pre1...v7.3.0) - 2026-02-04
+
+### <!-- 0 -->🚀 Features
+
+- cleanup the benchs and Cargo.toml ([#606](https://github.com/zip-rs/zip2/pull/606))
+- Add support for per-file comments ([#543](https://github.com/zip-rs/zip2/pull/543))
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- Document feature `unreserved` and make the mapping of extra fields public ([#616](https://github.com/zip-rs/zip2/pull/616))
+- Return an error if abort_file() fails when exceeding non-large-file limit ([#598](https://github.com/zip-rs/zip2/pull/598))
+
+### <!-- 7 -->⚙️ Miscellaneous Tasks
+
+- Bump version to 7.3.0 (semver checks fail if it's still 7.3.0-pre1)
+
 ## [7.3.0-pre1](https://github.com/zip-rs/zip2/compare/v7.2.0...v7.3.0-pre1) - 2026-01-27
 
 ### <!-- 1 -->🐛 Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `zip`: 7.3.0-pre1 -> 7.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [7.3.0](https://github.com/zip-rs/zip2/compare/v7.3.0-pre1...v7.3.0) - 2026-02-04

### <!-- 0 -->🚀 Features

- cleanup the benchs and Cargo.toml ([#606](https://github.com/zip-rs/zip2/pull/606))
- Add support for per-file comments ([#543](https://github.com/zip-rs/zip2/pull/543))

### <!-- 1 -->🐛 Bug Fixes

- Document feature `unreserved` and make the mapping of extra fields public ([#616](https://github.com/zip-rs/zip2/pull/616))
- Return an error if abort_file() fails when exceeding non-large-file limit ([#598](https://github.com/zip-rs/zip2/pull/598))

### <!-- 7 -->⚙️ Miscellaneous Tasks

- Bump version to 7.3.0 (semver checks fail if it's still 7.3.0-pre1)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).