### PR TITLE
test: Remove a println from test_absolute_paths

### DIFF
--- a/tests/absolute_paths.rs
+++ b/tests/absolute_paths.rs
@@ -29,8 +29,6 @@ fn test_absolute_paths() -> ZipResult<()> {
     // Try to read the ZIP file
     let mut archive = ZipArchive::new(std::io::Cursor::new(zip_data))?;
 
-    println!("ZIP file created with {} entries", archive.len());
-
     // Test individual file access
     assert_eq!(archive.len(), 3); // directory + 2 files
 


### PR DESCRIPTION
_This PR applies 1/2 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._