### PR TITLE
fix: Return an error if abort_file() fails when exceeding non-large-file limit

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -615,13 +615,15 @@ impl<W: Write + Seek> Write for ZipWriter<W> {
                             .1
                             .large_file
                     {
-                        if let Err(e) = self.abort_file() {
+                        return Err(if let Err(e) = self.abort_file() {
                             let abort_io_err: io::Error = e.into();
-                            return Err(io::Error::new(
+                            io::Error::new(
                                 abort_io_err.kind(),
                                 format!("Large file option has not been set and abort_file() failed: {abort_io_err}")
-                            ));
-                        }
+                            )
+                        } else {
+                            io::Error::other("Large file option has not been set")
+                        });
                     }
                 }
                 write_result


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._