### PR TITLE
ci: Revert "ci: Temporarily override baseline for semver checks (revert after 7.3.0 is released)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,6 @@ jobs:
         with:
           manifest-path: ${{ github.workspace }}/${{ matrix.workspace }}
           feature-group: ${{ matrix.feature_group }}
-          baseline-version: 7.3.0-pre1
   cargo_fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes #577