### PR TITLE
feat: Migrate to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["compression", "filesystem", "parser-implementations"]
 description = """
 Library to support the reading and writing of zip files.
 """
-edition = "2021"
+edition = "2024"
 exclude = ["tests/**", "examples/**", ".github/**", "fuzz/**", ".amazonq/**", "benches/**"]
 
 [package.metadata.docs.rs]

--- a/benches/merge_archive.rs
+++ b/benches/merge_archive.rs
@@ -3,7 +3,7 @@ use bencher::{benchmark_group, benchmark_main};
 use std::io::{Cursor, Read, Seek, Write};
 
 use bencher::Bencher;
-use zip::{result::ZipResult, write::SimpleFileOptions, ZipArchive, ZipWriter};
+use zip::{ZipArchive, ZipWriter, result::ZipResult, write::SimpleFileOptions};
 
 fn generate_random_archive(
     num_entries: usize,

--- a/benches/read_entry.rs
+++ b/benches/read_entry.rs
@@ -3,7 +3,7 @@ use bencher::{benchmark_group, benchmark_main};
 use std::io::{Cursor, Read, Write};
 
 use bencher::Bencher;
-use zip::{write::SimpleFileOptions, ZipArchive, ZipWriter};
+use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
 
 fn generate_random_archive(size: usize) -> Result<Vec<u8>, std::io::Error> {
     let data = Vec::new();

--- a/benches/read_metadata.rs
+++ b/benches/read_metadata.rs
@@ -6,7 +6,7 @@ use std::io::{Cursor, Write};
 use bencher::Bencher;
 use tempfile::TempDir;
 use zip::write::SimpleFileOptions;
-use zip::{result::ZipResult, CompressionMethod, ZipArchive, ZipWriter};
+use zip::{CompressionMethod, ZipArchive, ZipWriter, result::ZipResult};
 
 const FILE_COUNT: usize = 15_000;
 const FILE_SIZE: usize = 1024;

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 use std::fs;
 use std::io;
-use zip::result::ZipError;
 use zip::ZipArchive;
+use zip::result::ZipError;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<_> = std::env::args().collect();
@@ -92,17 +92,16 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("Directory {i} extracted to {:?}", out_path.display());
             }
         } else {
-            if let Some(p) = out_path.parent() {
-                if !p.exists() {
-                    if let Err(e) = fs::create_dir_all(p) {
-                        eprintln!(
-                            "Error: unable to create parent directory {p:?} of file {}: {e}",
-                            p.display()
-                        );
-                        some_files_failed = true;
-                        continue;
-                    }
-                }
+            if let Some(p) = out_path.parent()
+                && !p.exists()
+                && let Err(e) = fs::create_dir_all(p)
+            {
+                eprintln!(
+                    "Error: unable to create parent directory {p:?} of file {}: {e}",
+                    p.display()
+                );
+                some_files_failed = true;
+                continue;
             }
             match fs::File::create(&out_path)
                 .and_then(|mut outfile| io::copy(&mut file, &mut outfile))
@@ -130,14 +129,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         {
             use std::os::unix::fs::PermissionsExt;
 
-            if let Some(mode) = file.unix_mode() {
-                if let Err(e) = fs::set_permissions(&out_path, fs::Permissions::from_mode(mode)) {
-                    eprintln!(
-                        "Error: unable to change permissions of file {i} ({:?}): {e}",
-                        out_path.display()
-                    );
-                    some_files_failed = true;
-                }
+            if let Some(mode) = file.unix_mode()
+                && let Err(e) = fs::set_permissions(&out_path, fs::Permissions::from_mode(mode))
+            {
+                eprintln!(
+                    "Error: unable to change permissions of file {i} ({:?}): {e}",
+                    out_path.display()
+                );
+                some_files_failed = true;
             }
         }
     }

--- a/examples/write_sample.rs
+++ b/examples/write_sample.rs
@@ -1,9 +1,9 @@
 use std::error::Error;
 use std::io::{ErrorKind, Write};
 use std::path::Path;
+use zip::CompressionMethod::Stored;
 use zip::result::ZipError;
 use zip::write::SimpleFileOptions;
-use zip::CompressionMethod::Stored;
 #[cfg(all(feature = "aes-crypto", feature = "zstd"))]
 use zip::{AesMode, CompressionMethod::Zstd};
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["read", "write"]
 default-members = []
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 edition = "2024"

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -204,12 +204,10 @@ impl<R: Read> Read for AesReaderValid<R> {
 
             // use constant time comparison to mitigate timing attacks
             if !constant_time_eq(computed_auth_code, &read_auth_code) {
-                return Err(
-                    Error::new(
-                        ErrorKind::InvalidData,
-                        "Invalid authentication code, this could be due to an invalid password or errors in the data"
-                    )
-                );
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "Invalid authentication code, this could be due to an invalid password or errors in the data",
+                ));
             }
         }
 
@@ -359,7 +357,9 @@ mod tests {
     fn crypt_aes_256_0_byte() {
         let plaintext = &[];
         let password = b"some super secret password";
-        assert!(roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -367,7 +367,9 @@ mod tests {
         let plaintext = b"asdf\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes128, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes128, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -375,7 +377,9 @@ mod tests {
         let plaintext = b"asdf\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes192, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes192, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -383,7 +387,9 @@ mod tests {
         let plaintext = b"asdf\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -391,7 +397,9 @@ mod tests {
         let plaintext = b"Lorem ipsum dolor sit amet, consectetur\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes128, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes128, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -399,7 +407,9 @@ mod tests {
         let plaintext = b"Lorem ipsum dolor sit amet, consectetur\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes192, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes192, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 
     #[test]
@@ -407,6 +417,8 @@ mod tests {
         let plaintext = b"Lorem ipsum dolor sit amet, consectetur\n";
         let password = b"some super secret password";
 
-        assert!(roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt"));
+        assert!(
+            roundtrip(AesMode::Aes256, password, plaintext).expect("could encrypt and decrypt")
+        );
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -481,7 +481,7 @@ impl<R: io::BufRead> Decompressor<R> {
             _ => {
                 return Err(crate::result::ZipError::UnsupportedArchive(
                     "Compression method not supported",
-                ))
+                ));
             }
         })
     }

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -97,11 +97,13 @@ mod test {
         assert_eq!(reader.read(&mut buf).unwrap(), 0);
 
         let mut reader = Crc32Reader::new(data, 1, false);
-        assert!(reader
-            .read(&mut buf)
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid checksum"));
+        assert!(
+            reader
+                .read(&mut buf)
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid checksum")
+        );
     }
 
     #[test]

--- a/src/extra_fields/extended_timestamp.rs
+++ b/src/extra_fields/extended_timestamp.rs
@@ -113,9 +113,11 @@ mod test {
         use crate::ZipArchive;
         use std::io::Cursor;
 
-        assert!(ZipArchive::new(Cursor::new(include_bytes!(
-            "../../tests/data/extended_timestamp_bad.zip"
-        )))
-        .is_err());
+        assert!(
+            ZipArchive::new(Cursor::new(include_bytes!(
+                "../../tests/data/extended_timestamp_bad.zip"
+            )))
+            .is_err()
+        );
     }
 }

--- a/src/extra_fields/zipinfo_utf8.rs
+++ b/src/extra_fields/zipinfo_utf8.rs
@@ -1,4 +1,4 @@
-use crate::result::{invalid, ZipResult};
+use crate::result::{ZipResult, invalid};
 use crate::unstable::LittleEndianReadExt;
 use core::mem::size_of;
 use std::io::Read;

--- a/src/legacy/huffman.rs
+++ b/src/legacy/huffman.rs
@@ -63,7 +63,7 @@ impl HuffmanDecoder {
             count[lengths[i] as usize] += 1;
         }
         count[0] = 0; // Ignore zero-length codewords.
-                      // Compute sentinel_bits and offset_first_sym_idx for each length.
+        // Compute sentinel_bits and offset_first_sym_idx for each length.
         code[0] = 0;
         sym_idx[0] = 0;
         for l in 1..=MAX_HUFFMAN_BITS {
@@ -250,11 +250,12 @@ mod tests {
         );
 
         /* 1111111 (msb-first) -> 1111111 (lsb-first)*/
-        assert!(d
-            .huffman_decode(
+        assert!(
+            d.huffman_decode(
                 8,
                 &mut BitReader::endian(&mut Cursor::new(&[!0x7f]), LittleEndian)
             )
-            .is_err());
+            .is_err()
+        );
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,7 +5,7 @@ use crate::compression::{CompressionMethod, Decompressor};
 use crate::cp437::FromCp437;
 use crate::crc32::Crc32Reader;
 use crate::extra_fields::{ExtendedTimestamp, ExtraField, Ntfs, UsedExtraField};
-use crate::result::{invalid, ZipError, ZipResult};
+use crate::result::{ZipError, ZipResult, invalid};
 use crate::spec::{
     self, CentralDirectoryEndInfo, DataAndPosition, FixedSizeBlock, Pod, ZIP64_BYTES_THR,
 };
@@ -19,7 +19,7 @@ use core::ops::{Deref, Range};
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::ffi::OsStr;
-use std::io::{self, copy, sink, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write, copy, sink};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -113,7 +113,7 @@ use crate::extra_fields::UnicodeExtraField;
 use crate::result::ZipError::InvalidPassword;
 use crate::spec::is_dir;
 use crate::types::ffi::{S_IFLNK, S_IFREG};
-use crate::unstable::{path_to_string, LittleEndianReadExt};
+use crate::unstable::{LittleEndianReadExt, path_to_string};
 pub use zip_archive::ZipArchive;
 
 #[allow(clippy::large_enum_variant)]
@@ -403,7 +403,7 @@ pub(crate) fn make_crypto_reader<'a, R: Read + ?Sized>(
         (Some(_), Some(_)) => {
             return Err(ZipError::UnsupportedArchive(
                 "AES encrypted files cannot be decrypted without the aes-crypto feature.",
-            ))
+            ));
         }
         #[cfg(feature = "aes-crypto")]
         (Some(password), Some((aes_mode, vendor_version, _))) => CryptoReader::Aes {
@@ -505,7 +505,9 @@ impl<'a> TryFrom<&'a CentralDirectoryEndInfo> for CentralDirectoryInfo {
             match &value.eocd64 {
                 Some(DataAndPosition { data: eocd64, .. }) => {
                     if eocd64.number_of_files_on_this_disk > eocd64.number_of_files {
-                        return Err(invalid!("ZIP64 footer indicates more files on this disk than in the whole archive"));
+                        return Err(invalid!(
+                            "ZIP64 footer indicates more files on this disk than in the whole archive"
+                        ));
                     }
                     (
                         eocd64.central_directory_offset,
@@ -1010,10 +1012,10 @@ impl<R: Read + Seek> ZipArchive<R> {
 
             // Set original timestamp.
             #[cfg(feature = "chrono")]
-            if let Some(last_modified) = file.last_modified() {
-                if let Some(t) = datetime_to_systemtime(&last_modified) {
-                    outfile.set_modified(t)?;
-                }
+            if let Some(last_modified) = file.last_modified()
+                && let Some(t) = datetime_to_systemtime(&last_modified)
+            {
+                outfile.set_modified(t)?;
             }
         }
 
@@ -1182,7 +1184,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                     _ => {
                         return Err(ZipError::UnsupportedArchive(
                             "Seekable compressed files are not yet supported",
-                        ))
+                        ));
                     }
                 };
                 Ok(ZipFileSeek {
@@ -1262,7 +1264,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             // Require and use the password only if the file is encrypted.
             match (options.password, data.encrypted) {
                 (None, true) => {
-                    return Err(ZipError::UnsupportedArchive(ZipError::PASSWORD_REQUIRED))
+                    return Err(ZipError::UnsupportedArchive(ZipError::PASSWORD_REQUIRED));
                 }
                 // Password supplied, but none needed! Discard.
                 (Some(_), false) => options.password = None,
@@ -1569,7 +1571,7 @@ pub(crate) fn parse_single_extra_field<R: Read>(
     let len = match reader.read_u16_le() {
         Ok(len) => len,
         Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-            return Err(invalid!("Extra field header truncated"))
+            return Err(invalid!("Extra field header truncated"));
         }
         Err(e) => return Err(e.into()),
     };
@@ -1585,7 +1587,7 @@ pub(crate) fn parse_single_extra_field<R: Read>(
                 file.uncompressed_size = match reader.read_u64_le() {
                     Ok(v) => v,
                     Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                        return Err(invalid!("ZIP64 extra field truncated"))
+                        return Err(invalid!("ZIP64 extra field truncated"));
                     }
                     Err(e) => return Err(e.into()),
                 };
@@ -1595,7 +1597,7 @@ pub(crate) fn parse_single_extra_field<R: Read>(
                 file.compressed_size = match reader.read_u64_le() {
                     Ok(v) => v,
                     Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                        return Err(invalid!("ZIP64 extra field truncated"))
+                        return Err(invalid!("ZIP64 extra field truncated"));
                     }
                     Err(e) => return Err(e.into()),
                 };
@@ -1605,7 +1607,7 @@ pub(crate) fn parse_single_extra_field<R: Read>(
                 file.header_start = match reader.read_u64_le() {
                     Ok(v) => v,
                     Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                        return Err(invalid!("ZIP64 extra field truncated"))
+                        return Err(invalid!("ZIP64 extra field truncated"));
                     }
                     Err(e) => return Err(e.into()),
                 };
@@ -2236,14 +2238,12 @@ fn generate_chrono_datetime(datetime: &DateTime) -> Option<chrono::NaiveDateTime
         datetime.year().into(),
         datetime.month().into(),
         datetime.day().into(),
+    ) && let Some(d) = d.and_hms_opt(
+        datetime.hour().into(),
+        datetime.minute().into(),
+        datetime.second().into(),
     ) {
-        if let Some(d) = d.and_hms_opt(
-            datetime.hour().into(),
-            datetime.minute().into(),
-            datetime.second().into(),
-        ) {
-            return Some(d);
-        }
+        return Some(d);
     }
     None
 }
@@ -2298,10 +2298,10 @@ pub fn read_zipfile_from_stream_with_compressed_size<R: io::Read>(
 
 #[cfg(test)]
 mod test {
+    use crate::CompressionMethod::Stored;
     use crate::read::ZipReadOptions;
     use crate::result::ZipResult;
     use crate::types::SimpleFileOptions;
-    use crate::CompressionMethod::Stored;
     use crate::{ZipArchive, ZipWriter};
     use std::io::{Cursor, Read, Write};
     use tempfile::TempDir;

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -41,11 +41,7 @@ impl<'a> FinderDirection<'a> for Forward<'a> {
         let magic_overlap = self.needle().len().saturating_sub(1) as u64;
         let next = cursor.saturating_add(window_size as u64 - magic_overlap);
 
-        if next >= bounds.1 {
-            None
-        } else {
-            Some(next)
-        }
+        if next >= bounds.1 { None } else { Some(next) }
     }
 
     fn move_scope(&self, offset: usize) -> usize {

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -1,6 +1,6 @@
 use super::{
-    central_header_to_zip_file_inner, make_symlink, read_zipfile_from_stream, ZipCentralEntryBlock,
-    ZipFile, ZipFileData, ZipResult,
+    ZipCentralEntryBlock, ZipFile, ZipFileData, ZipResult, central_header_to_zip_file_inner,
+    make_symlink, read_zipfile_from_stream,
 };
 use crate::spec::FixedSizeBlock;
 use indexmap::IndexMap;
@@ -210,11 +210,11 @@ impl ZipStreamFileMetadata {
 mod test {
     use tempfile::TempDir;
 
-    use crate::read::stream::{ZipStreamFileMetadata, ZipStreamReader, ZipStreamVisitor};
+    use crate::ZipWriter;
     use crate::read::ZipFile;
+    use crate::read::stream::{ZipStreamFileMetadata, ZipStreamReader, ZipStreamVisitor};
     use crate::result::ZipResult;
     use crate::write::SimpleFileOptions;
-    use crate::ZipWriter;
     use std::collections::BTreeSet;
     use std::io::{Cursor, Read};
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,9 +1,9 @@
 #![macro_use]
 
 use crate::extra_fields::UsedExtraField;
-use crate::read::magic_finder::{Backwards, Forward, MagicFinder, OptimisticMagicFinder};
 use crate::read::ArchiveOffset;
-use crate::result::{invalid, ZipError, ZipResult};
+use crate::read::magic_finder::{Backwards, Forward, MagicFinder, OptimisticMagicFinder};
+use crate::result::{ZipError, ZipResult, invalid};
 use core::any::type_name;
 use core::mem;
 use core::slice;
@@ -843,7 +843,7 @@ mod test {
     use std::io::Cursor;
 
     use crate::{
-        result::{invalid, ZipError},
+        result::{ZipError, invalid},
         spec::{FixedSizeBlock, Magic, Pod},
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use typed_path::{Utf8WindowsComponent, Utf8WindowsPath};
 
-use crate::result::{invalid, ZipError, ZipResult};
+use crate::result::{ZipError, ZipResult, invalid};
 use crate::spec::{self, FixedSizeBlock, Pod};
 
 pub(crate) mod ffi {
@@ -317,7 +317,7 @@ impl DateTime {
         second: u8,
     ) -> Result<DateTime, DateTimeRangeError> {
         fn is_leap_year(year: u16) -> bool {
-            (year % 4 == 0) && ((year % 25 != 0) || (year % 16 == 0))
+            year.is_multiple_of(4) && (!year.is_multiple_of(25) || year.is_multiple_of(16))
         }
 
         if (1980..=2107).contains(&year)
@@ -1588,8 +1588,8 @@ mod test {
     #[cfg(all(feature = "time", feature = "deprecated-time"))]
     #[test]
     fn offset_datetime_try_from_datetime() {
-        use time::macros::datetime;
         use time::OffsetDateTime;
+        use time::macros::datetime;
 
         use super::DateTime;
 
@@ -1602,8 +1602,8 @@ mod test {
     #[cfg(feature = "time")]
     #[test]
     fn primitive_datetime_try_from_datetime() {
-        use time::macros::datetime;
         use time::PrimitiveDateTime;
+        use time::macros::datetime;
 
         use super::DateTime;
 
@@ -1620,16 +1620,16 @@ mod test {
         use time::OffsetDateTime;
 
         // 1980-00-00 00:00:00
-        assert!(OffsetDateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0x0000, 0x0000)
-        })
-        .is_err());
+        assert!(
+            OffsetDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0x0000, 0x0000) })
+                .is_err()
+        );
 
         // 2107-15-31 31:63:62
-        assert!(OffsetDateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF)
-        })
-        .is_err());
+        assert!(
+            OffsetDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF) })
+                .is_err()
+        );
     }
 
     #[cfg(feature = "time")]
@@ -1639,16 +1639,16 @@ mod test {
         use time::PrimitiveDateTime;
 
         // 1980-00-00 00:00:00
-        assert!(PrimitiveDateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0x0000, 0x0000)
-        })
-        .is_err());
+        assert!(
+            PrimitiveDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0x0000, 0x0000) })
+                .is_err()
+        );
 
         // 2107-15-31 31:63:62
-        assert!(PrimitiveDateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF)
-        })
-        .is_err());
+        assert!(
+            PrimitiveDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF) })
+                .is_err()
+        );
     }
 
     #[cfg(feature = "jiff-02")]
@@ -1709,16 +1709,16 @@ mod test {
         use super::DateTime;
 
         // 1980-00-00 00:00:00
-        assert!(civil::DateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0x0000, 0x0000)
-        })
-        .is_err());
+        assert!(
+            civil::DateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0x0000, 0x0000) })
+                .is_err()
+        );
 
         // 2107-15-31 31:63:62
-        assert!(civil::DateTime::try_from(unsafe {
-            DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF)
-        })
-        .is_err());
+        assert!(
+            civil::DateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF) })
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::io;
 use std::io::{Read, Write};
-use std::path::{Component, Path, MAIN_SEPARATOR};
+use std::path::{Component, MAIN_SEPARATOR, Path};
 
 /// Provides high level API for reading from a stream.
 pub mod stream {

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,19 +2,19 @@
 
 use crate::compression::CompressionMethod;
 use crate::extra_fields::UsedExtraField;
-use crate::read::{parse_single_extra_field, Config, ZipArchive, ZipFile};
-use crate::result::{invalid, ZipError, ZipResult};
+use crate::read::{Config, ZipArchive, ZipFile, parse_single_extra_field};
+use crate::result::{ZipError, ZipResult, invalid};
 use crate::spec::{self, FixedSizeBlock, Zip32CDEBlock};
 use crate::types::ffi::S_IFLNK;
 use crate::types::{
-    ffi, AesVendorVersion, DateTime, Zip64ExtraFieldBlock, ZipFileData, ZipLocalEntryBlock,
-    ZipRawValues, MIN_VERSION,
+    AesVendorVersion, DateTime, MIN_VERSION, Zip64ExtraFieldBlock, ZipFileData, ZipLocalEntryBlock,
+    ZipRawValues, ffi,
 };
 use core::default::Default;
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem::{self, offset_of, size_of};
-use core::str::{from_utf8, Utf8Error};
+use core::str::{Utf8Error, from_utf8};
 use crc32fast::Hasher;
 use indexmap::IndexMap;
 use std::borrow::ToOwned;
@@ -175,11 +175,11 @@ pub(crate) mod zip_writer {
 }
 #[doc(inline)]
 pub use self::sealed::FileOptionExtension;
-use crate::result::ZipError::UnsupportedArchive;
-use crate::unstable::path_to_string;
-use crate::unstable::LittleEndianWriteExt;
-use crate::zipcrypto::{EncryptWith, ZipCryptoKeys, CHUNK_SIZE};
 use crate::CompressionMethod::Stored;
+use crate::result::ZipError::UnsupportedArchive;
+use crate::unstable::LittleEndianWriteExt;
+use crate::unstable::path_to_string;
+use crate::zipcrypto::{CHUNK_SIZE, EncryptWith, ZipCryptoKeys};
 pub use zip_writer::ZipWriter;
 
 #[derive(Default, Debug)]
@@ -309,19 +309,19 @@ impl ExtendedFileOptions {
             #[cfg(not(feature = "unreserved"))]
             {
                 use crate::{
-                    extra_fields::{UsedExtraField, EXTRA_FIELD_MAPPING},
+                    extra_fields::{EXTRA_FIELD_MAPPING, UsedExtraField},
                     unstable::LittleEndianReadExt,
                 };
                 let header_id = data.read_u16_le()?;
                 // Some extra fields are authorized
-                if let Err(()) = UsedExtraField::try_from(header_id) {
-                    if EXTRA_FIELD_MAPPING.contains(&header_id) {
-                        return Err(ZipError::Io(io::Error::other(format!(
-                            "Extra data header ID {:#06} (0x{:x}) \
+                if let Err(()) = UsedExtraField::try_from(header_id)
+                    && EXTRA_FIELD_MAPPING.contains(&header_id)
+                {
+                    return Err(ZipError::Io(io::Error::other(format!(
+                        "Extra data header ID {:#06} (0x{:x}) \
                             requires crate feature \"unreserved\"",
-                            header_id, header_id,
-                        ))));
-                    }
+                        header_id, header_id,
+                    ))));
                 }
                 data.seek(SeekFrom::Current(-2))?;
             }
@@ -626,7 +626,9 @@ impl<W: Write + Seek> Write for ZipWriter<W> {
                             let abort_io_err: io::Error = e.into();
                             io::Error::new(
                                 abort_io_err.kind(),
-                                format!("Large file option has not been set and abort_file() failed: {abort_io_err}")
+                                format!(
+                                    "Large file option has not been set and abort_file() failed: {abort_io_err}"
+                                ),
                             )
                         } else {
                             io::Error::other("Large file option has not been set")
@@ -1793,13 +1795,13 @@ impl<W: Write> ZipWriter<StreamWriter<W>> {
 
 impl<W: Write + Seek> Drop for ZipWriter<W> {
     fn drop(&mut self) {
-        if !self.inner.is_closed() {
-            if let Err(e) = self.finalize() {
-                let _ = write!(
-                    io::stderr(),
-                    "ZipWriter::drop: failed to finalize archive: {e:?}"
-                );
-            }
+        if !self.inner.is_closed()
+            && let Err(e) = self.finalize()
+        {
+            let _ = write!(
+                io::stderr(),
+                "ZipWriter::drop: failed to finalize archive: {e:?}"
+            );
         }
     }
 }
@@ -2056,21 +2058,21 @@ impl<W: Write + Seek> GenericZipWriter<W> {
 
     fn ref_mut(&mut self) -> Option<&mut dyn Write> {
         match self {
-            GenericZipWriter::Storer(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Storer(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "deflate-flate2")]
-            GenericZipWriter::Deflater(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Deflater(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "deflate-zopfli")]
             GenericZipWriter::ZopfliDeflater(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "deflate-zopfli")]
             GenericZipWriter::BufferedZopfliDeflater(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "_bzip2_any")]
-            GenericZipWriter::Bzip2(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Bzip2(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "zstd")]
-            GenericZipWriter::Zstd(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Zstd(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "xz")]
-            GenericZipWriter::Xz(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Xz(w) => Some(w as &mut dyn Write),
             #[cfg(feature = "ppmd")]
-            GenericZipWriter::Ppmd(ref mut w) => Some(w as &mut dyn Write),
+            GenericZipWriter::Ppmd(w) => Some(w as &mut dyn Write),
             GenericZipWriter::Closed => None,
         }
     }
@@ -2367,14 +2369,14 @@ impl<W: Write> Seek for StreamWriter<W> {
 #[allow(clippy::octal_escapes)] // many false positives in converted fuzz cases
 mod test {
     use super::{ExtendedFileOptions, FileOptions, FullFileOptions, ZipWriter};
+    use crate::CompressionMethod::Stored;
+    use crate::ZipArchive;
     use crate::compression::CompressionMethod;
     use crate::result::ZipResult;
     use crate::types::{DateTime, System};
     use crate::write::EncryptWith::ZipCrypto;
     use crate::write::SimpleFileOptions;
     use crate::zipcrypto::ZipCryptoKeys;
-    use crate::CompressionMethod::Stored;
-    use crate::ZipArchive;
     #[cfg(feature = "deflate-flate2")]
     use std::io::Read;
     use std::io::{Cursor, Write};
@@ -2395,7 +2397,9 @@ mod test {
         assert_eq!(result.get_ref().len(), 25);
         assert_eq!(
             *result.get_ref(),
-            [80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 90, 73, 80]
+            [
+                80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 90, 73, 80
+            ]
         );
     }
 
@@ -2460,9 +2464,11 @@ mod test {
                 ),
             )
             .unwrap();
-        assert!(writer
-            .write(b"writing to a directory is not allowed, and will not write any data")
-            .is_err());
+        assert!(
+            writer
+                .write(b"writing to a directory is not allowed, and will not write any data")
+                .is_err()
+        );
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 108);
         const DOS_DIR_ATTRIBUTES_BYTE: u8 = if cfg!(windows) { 0x10 } else { 0 };
@@ -2491,9 +2497,11 @@ mod test {
                 ),
             )
             .unwrap();
-        assert!(writer
-            .write(b"writing to a symlink is not allowed and will not write any data")
-            .is_err());
+        assert!(
+            writer
+                .write(b"writing to a symlink is not allowed and will not write any data")
+                .is_err()
+        );
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 112);
         #[rustfmt::skip]
@@ -2537,9 +2545,11 @@ mod test {
                 ),
             )
             .unwrap();
-        assert!(writer
-            .write(b"writing to a symlink is not allowed and will not write any data")
-            .is_err());
+        assert!(
+            writer
+                .write(b"writing to a symlink is not allowed and will not write any data")
+                .is_err()
+        );
         let result = writer.finish().unwrap();
         assert_eq!(result.get_ref().len(), 162);
         #[rustfmt::skip]
@@ -3371,8 +3381,8 @@ mod test {
     #[cfg(all(feature = "_deflate-any", feature = "aes-crypto"))]
     #[test]
     fn test_fuzz_crash_2024_06_14d() -> ZipResult<()> {
-        use crate::write::EncryptWith::Aes;
         use crate::AesMode::Aes256;
+        use crate::write::EncryptWith::Aes;
         use CompressionMethod::Deflated;
         let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer.set_flush_on_finish_file(false);
@@ -4086,8 +4096,8 @@ mod test {
     #[test]
     #[cfg(feature = "aes-crypto")]
     fn fuzz_crash_2024_07_19a() -> ZipResult<()> {
-        use crate::write::EncryptWith::Aes;
         use crate::AesMode::Aes128;
+        use crate::write::EncryptWith::Aes;
         let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
         writer.set_flush_on_finish_file(false);
         let options = FileOptions {

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "aes-crypto")]
 
 use std::io::{self, Read, Write};
-use zip::write::ZipWriter;
 #[cfg(feature = "deflate-flate2")]
 use zip::CompressionMethod::Deflated;
-use zip::{result::ZipError, write::SimpleFileOptions, AesMode, ZipArchive};
+use zip::write::ZipWriter;
+use zip::{AesMode, ZipArchive, result::ZipError, write::SimpleFileOptions};
 
 const SECRET_CONTENT: &str = "Lorem ipsum dolor sit amet";
 

--- a/tests/append_near_4gb.rs
+++ b/tests/append_near_4gb.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Write};
 use tempfile::tempdir;
-use zip::{write::SimpleFileOptions, ZipWriter};
+use zip::{ZipWriter, write::SimpleFileOptions};
 
 fn write_data(w: &mut dyn Write, size: usize) {
     let chunks = 1 << 20; // 1MB chunks

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -5,7 +5,7 @@ use zip::unstable::LittleEndianWriteExt;
 use zip::write::ExtendedFileOptions;
 use zip::write::FileOptions;
 use zip::write::SimpleFileOptions;
-use zip::{CompressionMethod, ZipWriter, SUPPORTED_COMPRESSION_METHODS};
+use zip::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS, ZipWriter};
 
 fn for_each_supported_method<F>(mut f: F)
 where

--- a/tests/invalid_path.rs
+++ b/tests/invalid_path.rs
@@ -112,10 +112,12 @@ pub mod tests {
         assert!(temp_dir.path().join("_").exists());
         assert!(temp_dir.path().join("_/forge-std").exists());
         assert!(temp_dir.path().join("_/forge-std/src/Test.sol").exists());
-        assert!(temp_dir
-            .path()
-            .join("_/forge-std/lib/ds-test/src/test.sol")
-            .exists());
+        assert!(
+            temp_dir
+                .path()
+                .join("_/forge-std/lib/ds-test/src/test.sol")
+                .exists()
+        );
 
         // Verify file contents
         let content =


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

The current MSRV of this crate is 1.88, so we can migrate the edition to Rust 2024. The current `edition` field is 2021, so the edition of this crate is Rust 2021.

Also fixed [`clippy::manual_is_multiple_of`](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#manual_is_multiple_of) and [`clippy::collapsible_if`](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#collapsible_if) by [let chains](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#let-chains) to pass `cargo clippy`.