### PR TITLE
chore: release v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.0](https://github.com/zip-rs/zip2/compare/v8.1.0...v8.2.0) - 2026-03-02
+
+### <!-- 0 -->🚀 Features
+
+- allow custom salt ([#680](https://github.com/zip-rs/zip2/pull/680))
+- Support compressing bzip2 when feature `bzip2-rs` is enabled, since `bzip2/bzip2-sys` now supports it ([#685](https://github.com/zip-rs/zip2/pull/685))
+- enforce clippy in CI ([#674](https://github.com/zip-rs/zip2/pull/674))
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- zip64 central header (issue 617) ([#629](https://github.com/zip-rs/zip2/pull/629))
+- allow aes password as bytes ([#686](https://github.com/zip-rs/zip2/pull/686))
+- handle extra field padding ([#682](https://github.com/zip-rs/zip2/pull/682))
+
+### <!-- 2 -->🚜 Refactor
+
+- Simplify 2 type conversions in src/write.rs ([#687](https://github.com/zip-rs/zip2/pull/687))
+
+### <!-- 4 -->⚡ Performance
+
+- AI tweaks for string type conversions in src/types.rs ([#670](https://github.com/zip-rs/zip2/pull/670))
+
 ## [8.1.0](https://github.com/zip-rs/zip2/compare/v8.0.0...v8.1.0) - 2026-02-16
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "8.1.0"
+version = "8.2.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",


### PR DESCRIPTION



## 🤖 New release

* `zip`: 8.1.0 -> 8.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.2.0](https://github.com/zip-rs/zip2/compare/v8.1.0...v8.2.0) - 2026-03-02

### <!-- 0 -->🚀 Features

- allow custom salt ([#680](https://github.com/zip-rs/zip2/pull/680))
- Support compressing bzip2 when feature `bzip2-rs` is enabled, since `bzip2/bzip2-sys` now supports it ([#685](https://github.com/zip-rs/zip2/pull/685))
- enforce clippy in CI ([#674](https://github.com/zip-rs/zip2/pull/674))

### <!-- 1 -->🐛 Bug Fixes

- zip64 central header (issue 617) ([#629](https://github.com/zip-rs/zip2/pull/629))
- allow aes password as bytes ([#686](https://github.com/zip-rs/zip2/pull/686))
- handle extra field padding ([#682](https://github.com/zip-rs/zip2/pull/682))

### <!-- 2 -->🚜 Refactor

- Simplify 2 type conversions in src/write.rs ([#687](https://github.com/zip-rs/zip2/pull/687))

### <!-- 4 -->⚡ Performance

- AI tweaks for string type conversions in src/types.rs ([#670](https://github.com/zip-rs/zip2/pull/670))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).