### PR TITLE
feat: Support compressing bzip2 using `bzip2/bzip2-sys`, and remove `_bzip2_any` feature flag since `dep:bzip2` does the same thing

### DIFF
--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-rust-cargo-hack-${{ hashFiles('Cargo.toml') }}
-      - run: cargo hack test --feature-powerset --all-targets --exclude-features _bzip2_any,_arbitrary,_deflate-any
+      - run: cargo hack test --feature-powerset --all-targets --exclude-features _arbitrary,_deflate-any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,7 @@ ppmd = ["dep:ppmd-rust"]
 # This feature allows writing custom extra-data field IDs in file headers.
 unreserved = []
 xz = ["dep:lzma-rust2"]
-_bzip2_any = []
-bzip2 = ["dep:bzip2", "bzip2/default", "_bzip2_any"]
+bzip2 = ["dep:bzip2", "bzip2/default"]
 legacy-zip = ["bitstream-io"]
 time = ["dep:time"]
 default = [
@@ -116,7 +115,7 @@ default = [
 ]
 
 # The following features are not supported on wasm
-bzip2-rs = ["dep:bzip2", "bzip2/bzip2-sys", "_bzip2_any"]
+bzip2-rs = ["bzip2/bzip2-sys"]
 # Pull in flate2 and the zlib backend; only use this if you need a dynamically linked system zlib
 deflate-flate2-zlib = ["deflate-flate2", "flate2/zlib"]
 # Pull in flate2 and the zlib-ng backend; a modern fork of zlib

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             CompressionMethod::Deflated => {
                 is_feature!("_deflate-any", zip::CompressionMethod::Deflated)
             }
-            CompressionMethod::Bzip2 => is_feature!("_bzip2_any", zip::CompressionMethod::Bzip2),
+            CompressionMethod::Bzip2 => is_feature!("dep:bzip2", zip::CompressionMethod::Bzip2),
             CompressionMethod::Xz => is_feature!("xz", zip::CompressionMethod::Xz),
             CompressionMethod::Zstd => is_feature!("zstd", zip::CompressionMethod::Zstd),
         };

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -26,7 +26,7 @@ pub enum CompressionMethod {
     #[cfg(feature = "deflate64")]
     Deflate64,
     /// Compress the file using BZIP2
-    #[cfg(feature = "_bzip2_any")]
+    #[cfg(feature = "dep:bzip2")]
     Bzip2,
     /// Encrypted using AES.
     ///
@@ -110,9 +110,9 @@ impl CompressionMethod {
     #[cfg(not(feature = "deflate64"))]
     pub const DEFLATE64: Self = CompressionMethod::Unsupported(9);
     pub const PKWARE_IMPLODE: Self = CompressionMethod::Unsupported(10);
-    #[cfg(feature = "_bzip2_any")]
+    #[cfg(feature = "dep:bzip2")]
     pub const BZIP2: Self = CompressionMethod::Bzip2;
-    #[cfg(not(feature = "_bzip2_any"))]
+    #[cfg(not(feature = "dep:bzip2"))]
     pub const BZIP2: Self = CompressionMethod::Unsupported(12);
     #[cfg(not(feature = "lzma"))]
     pub const LZMA: Self = CompressionMethod::Unsupported(14);
@@ -144,10 +144,10 @@ impl CompressionMethod {
     #[cfg(feature = "_deflate-any")]
     pub const DEFAULT: Self = CompressionMethod::Deflated;
 
-    #[cfg(all(not(feature = "_deflate-any"), feature = "_bzip2_any"))]
+    #[cfg(all(not(feature = "_deflate-any"), feature = "dep:bzip2"))]
     pub const DEFAULT: Self = CompressionMethod::Bzip2;
 
-    #[cfg(all(not(feature = "_deflate-any"), not(feature = "_bzip2_any")))]
+    #[cfg(all(not(feature = "_deflate-any"), not(feature = "dep:bzip2")))]
     pub const DEFAULT: Self = CompressionMethod::Stored;
 }
 impl CompressionMethod {
@@ -170,7 +170,7 @@ impl CompressionMethod {
             8 => CompressionMethod::Deflated,
             #[cfg(feature = "deflate64")]
             9 => CompressionMethod::Deflate64,
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             12 => CompressionMethod::Bzip2,
             #[cfg(feature = "lzma")]
             14 => CompressionMethod::Lzma,
@@ -211,7 +211,7 @@ impl CompressionMethod {
             CompressionMethod::Deflated => 8,
             #[cfg(feature = "deflate64")]
             CompressionMethod::Deflate64 => 9,
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             CompressionMethod::Bzip2 => 12,
             #[cfg(feature = "aes-crypto")]
             CompressionMethod::Aes => 99,
@@ -262,7 +262,7 @@ pub const SUPPORTED_COMPRESSION_METHODS: &[CompressionMethod] = &[
     CompressionMethod::Deflated,
     #[cfg(feature = "deflate64")]
     CompressionMethod::Deflate64,
-    #[cfg(feature = "_bzip2_any")]
+    #[cfg(feature = "dep:bzip2")]
     CompressionMethod::Bzip2,
     #[cfg(feature = "zstd")]
     CompressionMethod::Zstd,
@@ -278,7 +278,7 @@ pub(crate) enum Decompressor<R: io::BufRead> {
     Deflated(flate2::bufread::DeflateDecoder<R>),
     #[cfg(feature = "deflate64")]
     Deflate64(deflate64::Deflate64Decoder<R>),
-    #[cfg(feature = "_bzip2_any")]
+    #[cfg(feature = "dep:bzip2")]
     Bzip2(bzip2::bufread::BzDecoder<R>),
     #[cfg(feature = "zstd")]
     Zstd(zstd::Decoder<'static, R>),
@@ -319,7 +319,7 @@ impl<R: io::BufRead> io::Read for Decompressor<R> {
             Decompressor::Deflated(r) => r.read(buf),
             #[cfg(feature = "deflate64")]
             Decompressor::Deflate64(r) => r.read(buf),
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             Decompressor::Bzip2(r) => r.read(buf),
             #[cfg(feature = "zstd")]
             Decompressor::Zstd(r) => r.read(buf),
@@ -451,7 +451,7 @@ impl<R: io::BufRead> Decompressor<R> {
             CompressionMethod::Deflate64 => {
                 Decompressor::Deflate64(deflate64::Deflate64Decoder::with_buffer(reader))
             }
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             CompressionMethod::Bzip2 => Decompressor::Bzip2(bzip2::bufread::BzDecoder::new(reader)),
             #[cfg(feature = "zstd")]
             CompressionMethod::Zstd => Decompressor::Zstd(zstd::Decoder::with_buffer(reader)?),
@@ -495,7 +495,7 @@ impl<R: io::BufRead> Decompressor<R> {
             Decompressor::Deflated(r) => r.into_inner(),
             #[cfg(feature = "deflate64")]
             Decompressor::Deflate64(r) => r.into_inner(),
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             Decompressor::Bzip2(r) => r.into_inner(),
             #[cfg(feature = "zstd")]
             Decompressor::Zstd(r) => r.finish(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -717,7 +717,7 @@ impl ZipFileData {
             CompressionMethod::Stored => MIN_VERSION.into(),
             #[cfg(feature = "_deflate-any")]
             CompressionMethod::Deflated => 20,
-            #[cfg(feature = "_bzip2_any")]
+            #[cfg(feature = "dep:bzip2")]
             CompressionMethod::Bzip2 => 46,
             #[cfg(feature = "deflate64")]
             CompressionMethod::Deflate64 => 21,


### PR DESCRIPTION
<!-- 
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Please make sure your PR's target repo is `zip-rs/zip2` and not `zip-rs/zip-old`. The latter
  repo is no longer maintained, and I will archive it after closing the pre-existing issues.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start 
  with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
  This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged.

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->
