### PR TITLE
style: ZipCrypto decryption didn't match APPNOTE (bitwise or by 3 instead of 2), even though key streams are the same

### DIFF
--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -82,7 +82,7 @@ impl ZipCryptoKeys {
     /// Constant added to the lower 2 bits of `key_2` when computing the
     /// ZipCrypto keystream base, corresponding to the `| 3` step described
     /// in the ZipCrypto specification.
-    const KEYSTREAM_BASE_SUFFIX: u16 = 3;
+    const KEYSTREAM_BASE_SUFFIX: u16 = 2;
 
     const fn new() -> ZipCryptoKeys {
         ZipCryptoKeys {


### PR DESCRIPTION
From APPNOTE v6.3.10 at 6.1.6:
```
    Where decrypt_byte() is defined as:

    unsigned char decrypt_byte()
        local unsigned short temp
        temp <- Key(2) | 2
        decrypt_byte <- (temp * (temp ^ 1)) >> 8
    end decrypt_byte
```
The effect of using 3 instead of 2 cancels out when `(temp * (temp ^ 1))` is being calculated, because the two multiplication inputs swap.