### PR TITLE
feat: EXPERIMENT: dyn trait object injection for customizable read pipeline

### DIFF
--- a/examples/injection_validation_reader.rs
+++ b/examples/injection_validation_reader.rs
@@ -1,0 +1,40 @@
+//! Read a ZIP archive with CRC checking disabled by using a custom final reader.
+//! The built-in final reader (Crc32Reader) is replaced with a pass-through that does not validate CRC.
+
+use std::fs::File;
+use std::io::Read;
+use std::sync::Arc;
+use zip::read::Config;
+use zip::{ValidatorReaderFactory, ZipArchive, ZipReadOptions};
+
+/// Final reader that just passes through the decompressed stream (no CRC validation).
+fn skip_crc_check<'a>(
+    inner: Box<dyn Read + 'a>,
+    _crc32: u32,
+    _ae2: bool,
+) -> Box<dyn Read + 'a> {
+    inner
+}
+
+fn main() -> zip::result::ZipResult<()> {
+    // Override with your file; make sure to use a small dummy zip
+    let file = File::open("/home/user/dummy.zip")?;
+    let config = Config::default();
+    let mut archive = ZipArchive::with_config(config, file)?;
+
+    let factory: Arc<ValidatorReaderFactory> = Arc::new(skip_crc_check);
+
+    for i in 0..archive.len() {
+        let options = ZipReadOptions::new().final_reader_factory(Some(Arc::clone(&factory)));
+        let mut zip_file = archive.by_index_with_options(i, options)?;
+        println!("Filename: {}", zip_file.name());
+        println!("---");
+        let mut buf = Vec::new();
+        zip_file.read_to_end(&mut buf)?;
+        let content = String::from_utf8_lossy(&buf);
+        print!("{content}");
+        println!("---");
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 #![allow(clippy::multiple_crate_versions)] // https://github.com/rust-lang/rust-clippy/issues/16440
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};
 pub use crate::read::HasZipMetadata;
-pub use crate::read::{ZipArchive, ZipReadOptions};
+pub use crate::read::{ValidatorReaderFactory, ZipArchive, ZipReadOptions};
 pub use crate::spec::{ZIP64_BYTES_THR, ZIP64_ENTRY_THR};
 pub use crate::types::{AesMode, DateTime, System};
 pub use crate::write::ZipWriter;


### PR DESCRIPTION
As discussed extensively in #170 (and also in #223), this is a proof of concept.

The library maintains a zero-cost, highly optimizable path for the standard flow, while adding flexibility for users who need something more specific.

For this prototype, I focused on the read pipeline and implemented customization for the validation layer (CRC), as it was the simplest layer to experiment with.


```rust

            ZipFileReader::NoReader => invalid_state(),
            ZipFileReader::Raw(r) => r.read(buf),
            ZipFileReader::Compressed(CompressedInner::Builtin(r)) => r.read(buf),
 >>>        ZipFileReader::Compressed(CompressedInner::Custom(r)) => r.read(buf),
        
```

As shown above, the enum grows for each custom reader. Currently, this is implemented only for validation, but the same issue applies to encryption and compression. I need to research for a more general and scalable approach that works uniformly across layers. For example, if a user customizes one layer, they may also need to provide implementations for the others.

The contract would be: full flexibility is possible, but it comes with trade-offs. Users opting into customization would also take responsibility for the added complexity and potential issues.
Not every requested feature or potentially useful extension should necessarily be included in the library.


Regarding the cost of dynamic dispatch, I found this [good explanation of the overhead](https://lukefleed.xyz/posts/who-owns-the-memory-pt3/#trait-object-representation) .  

