### PR TITLE
style: Rename KEYSTREAM_BASE_SUFFIX to KEYSTREAM_BITMASK and clarify comment

### DIFF
--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -79,9 +79,10 @@ impl ZipCryptoKeys {
     /// Initial value of `key_2` as specified by the classic ZipCrypto algorithm.
     const INITIAL_KEY_2: u32 = 0x34567890;
 
-    /// Constant added to the lower 2 bits of `key_2` when computing the
+    /// Bitmask applied to the lower 2 bits of `key_2` when computing the
     /// ZipCrypto keystream base, corresponding to the step described
-    /// in the ZipCrypto specification variously as `| 2` or `| 3` (both give the same keystream).
+    /// in the ZipCrypto specification variously as `| 2` or `| 3` (both give the same keystream
+    /// due to the use of `keystream_base * (keystream_base ^ Wrapping(1))` and a quirk of CRC32).
     const KEYSTREAM_BITMASK: u16 = 2;
 
     const fn new() -> ZipCryptoKeys {


### PR DESCRIPTION
Clarifies the comment re `| 2` vs `| 3` discrepancy.