### PR TITLE
deps: avoid pulling in `zeroize_derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ nt-time = { version = "0.13", default-features = false, optional = true }
 ppmd-rust = { version = "1.4", optional = true }
 pbkdf2 = { version = "0.12", optional = true }
 sha1 = { version = "0.10", optional = true }
-zeroize = { version = "1.8", optional = true, features = ["zeroize_derive"] }
+zeroize = { version = "1.8", optional = true }
 zstd = { version = "^0.13.3", optional = true, default-features = false }
 zopfli = { version = "^0.8.3", optional = true }
 deflate64 = { version = "^0.1.10", optional = true }


### PR DESCRIPTION
This prevents pulling in any heavy proc macro deps (`syn`, `quote`, `proc-macro2`, etc).
