### PR TITLE
refactor: change magic finder to stack buffer

### DIFF
--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -96,7 +96,9 @@ impl<'a> FinderDirection<'a, MagicSize> for Backwards<'a> {
     }
 }
 
-const BUFFER_SIZE: usize = 2048;
+
+/// The buffer size that the finder will search
+const BUFFER_SIZE: usize = 1024;
 
 /// A utility for finding magic symbols from the end of a seekable reader.
 ///

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -111,8 +111,11 @@ pub(crate) struct MagicFinder<Direction> {
 
 impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
     /// Create a new magic bytes finder to look within specific bounds.
-    pub(crate) fn new(magic_bytes: &'a MagicSize, start_inclusive: u64, end_exclusive: u64) -> Self {
-
+    pub(crate) fn new(
+        magic_bytes: &'a MagicSize,
+        start_inclusive: u64,
+        end_exclusive: u64,
+    ) -> Self {
         // Smaller buffer size would be unable to locate bytes.
         // Equal buffer size would stall (the window could not be moved).
         debug_assert!(BUFFER_SIZE >= magic_bytes.len());
@@ -127,7 +130,11 @@ impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
     }
 
     /// Repurpose the finder for different bytes or bounds.
-    pub(crate) fn repurpose(&mut self, magic_bytes: &'a MagicSize, bounds: (u64, u64)) -> &mut Self {
+    pub(crate) fn repurpose(
+        &mut self,
+        magic_bytes: &'a MagicSize,
+        bounds: (u64, u64),
+    ) -> &mut Self {
         debug_assert!(self.buffer.len() >= magic_bytes.len());
 
         self.finder = T::new(magic_bytes);
@@ -141,7 +148,10 @@ impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
     }
 
     /// Find the next magic bytes in the direction specified in the type.
-    pub(crate) fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
+    pub(crate) fn next<R: Read + Seek + ?Sized>(
+        &mut self,
+        reader: &mut R,
+    ) -> ZipResult<Option<u64>> {
         loop {
             if self.cursor < self.bounds.0 || self.cursor >= self.bounds.1 {
                 // The finder is consumed
@@ -233,7 +243,6 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
         bounds: (u64, u64),
         initial_guess: Option<(u64, bool)>,
     ) -> &mut Self {
-
         self.inner.repurpose(magic_bytes, bounds);
         self.initial_guess = initial_guess;
 
@@ -242,7 +251,10 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
 
     /// Equivalent to `next_back`, with an optional initial guess attempted before
     /// proceeding with reading from the back of the reader.
-    pub(crate) fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
+    pub(crate) fn next<R: Read + Seek + ?Sized>(
+        &mut self,
+        reader: &mut R,
+    ) -> ZipResult<Option<u64>> {
         if let Some((v, mandatory)) = self.initial_guess {
             reader.seek(SeekFrom::Start(v))?;
 

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -4,8 +4,10 @@ use memchr::memmem::{Finder, FinderRev};
 
 use crate::result::ZipResult;
 
-pub trait FinderDirection<'a> {
-    fn new(needle: &'a [u8]) -> Self;
+type MagicSize = [u8; 4];
+
+pub(crate) trait FinderDirection<'a, B> {
+    fn new(needle: &'a B) -> Self;
     fn reset_cursor(bounds: (u64, u64), window_size: usize) -> u64;
     fn scope_window(window: &[u8], mid_window_offset: usize) -> (&[u8], usize);
 
@@ -15,9 +17,9 @@ pub trait FinderDirection<'a> {
     fn move_scope(&self, offset: usize) -> usize;
 }
 
-pub struct Forward<'a>(Finder<'a>);
-impl<'a> FinderDirection<'a> for Forward<'a> {
-    fn new(needle: &'a [u8]) -> Self {
+pub(crate) struct Forward<'a>(Finder<'a>);
+impl<'a> FinderDirection<'a, MagicSize> for Forward<'a> {
+    fn new(needle: &'a MagicSize) -> Self {
         Self(Finder::new(needle))
     }
 
@@ -49,9 +51,9 @@ impl<'a> FinderDirection<'a> for Forward<'a> {
     }
 }
 
-pub struct Backwards<'a>(FinderRev<'a>);
-impl<'a> FinderDirection<'a> for Backwards<'a> {
-    fn new(needle: &'a [u8]) -> Self {
+pub(crate) struct Backwards<'a>(FinderRev<'a>);
+impl<'a> FinderDirection<'a, MagicSize> for Backwards<'a> {
+    fn new(needle: &'a MagicSize) -> Self {
         Self(FinderRev::new(needle))
     }
 
@@ -94,28 +96,29 @@ impl<'a> FinderDirection<'a> for Backwards<'a> {
     }
 }
 
+const BUFFER_SIZE: usize = 2048;
+
 /// A utility for finding magic symbols from the end of a seekable reader.
 ///
 /// Can be repurposed to recycle the internal buffer.
 pub struct MagicFinder<Direction> {
-    buffer: Box<[u8]>,
+    buffer: [u8; BUFFER_SIZE],
     pub(self) finder: Direction,
     cursor: u64,
     mid_buffer_offset: Option<usize>,
     bounds: (u64, u64),
 }
 
-impl<'a, T: FinderDirection<'a>> MagicFinder<T> {
+impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
     /// Create a new magic bytes finder to look within specific bounds.
-    pub fn new(magic_bytes: &'a [u8], start_inclusive: u64, end_exclusive: u64) -> Self {
-        const BUFFER_SIZE: usize = 2048;
+    pub(crate) fn new(magic_bytes: &'a MagicSize, start_inclusive: u64, end_exclusive: u64) -> Self {
 
         // Smaller buffer size would be unable to locate bytes.
         // Equal buffer size would stall (the window could not be moved).
         debug_assert!(BUFFER_SIZE >= magic_bytes.len());
 
         Self {
-            buffer: vec![0; BUFFER_SIZE].into_boxed_slice(),
+            buffer: [0; BUFFER_SIZE],
             finder: T::new(magic_bytes),
             cursor: T::reset_cursor((start_inclusive, end_exclusive), BUFFER_SIZE),
             mid_buffer_offset: None,
@@ -124,7 +127,7 @@ impl<'a, T: FinderDirection<'a>> MagicFinder<T> {
     }
 
     /// Repurpose the finder for different bytes or bounds.
-    pub fn repurpose(&mut self, magic_bytes: &'a [u8], bounds: (u64, u64)) -> &mut Self {
+    pub(crate) fn repurpose(&mut self, magic_bytes: &'a MagicSize, bounds: (u64, u64)) -> &mut Self {
         debug_assert!(self.buffer.len() >= magic_bytes.len());
 
         self.finder = T::new(magic_bytes);
@@ -138,7 +141,7 @@ impl<'a, T: FinderDirection<'a>> MagicFinder<T> {
     }
 
     /// Find the next magic bytes in the direction specified in the type.
-    pub fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
+    pub(crate) fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
         loop {
             if self.cursor < self.bounds.0 || self.cursor >= self.bounds.1 {
                 // The finder is consumed
@@ -209,7 +212,7 @@ impl<'a, T: FinderDirection<'a>> MagicFinder<T> {
 ///
 /// The guess can be marked as mandatory to produce an error. This is useful
 /// if the `ArchiveOffset` is known and auto-detection is not desired.
-pub struct OptimisticMagicFinder<Direction> {
+pub(crate) struct OptimisticMagicFinder<Direction> {
     inner: MagicFinder<Direction>,
     initial_guess: Option<(u64, bool)>,
 }
@@ -219,19 +222,19 @@ pub struct OptimisticMagicFinder<Direction> {
 /// We only use magic bytes of size 4 at the moment.
 const STACK_BUFFER_SIZE: usize = 8;
 
-impl<'a, Direction: FinderDirection<'a>> OptimisticMagicFinder<Direction> {
+impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direction> {
     /// Create a new empty optimistic magic bytes finder.
-    pub fn new_empty() -> Self {
+    pub(crate) fn new(magic_bytes: &'a MagicSize) -> Self {
         Self {
-            inner: MagicFinder::new(&[], 0, 0),
+            inner: MagicFinder::new(magic_bytes, 0, 0),
             initial_guess: None,
         }
     }
 
     /// Repurpose the finder for different bytes, bounds and initial guesses.
-    pub fn repurpose(
+    pub(crate) fn repurpose(
         &mut self,
-        magic_bytes: &'a [u8],
+        magic_bytes: &'a MagicSize,
         bounds: (u64, u64),
         initial_guess: Option<(u64, bool)>,
     ) -> &mut Self {
@@ -245,7 +248,7 @@ impl<'a, Direction: FinderDirection<'a>> OptimisticMagicFinder<Direction> {
 
     /// Equivalent to `next_back`, with an optional initial guess attempted before
     /// proceeding with reading from the back of the reader.
-    pub fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
+    pub(crate) fn next<R: Read + Seek + ?Sized>(&mut self, reader: &mut R) -> ZipResult<Option<u64>> {
         if let Some((v, mandatory)) = self.initial_guess {
             reader.seek(SeekFrom::Start(v))?;
 

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -1,16 +1,16 @@
-use std::io::{Read, Seek, SeekFrom};
+//! Code related to the MagicFinder
 
+use std::io::{Read, Seek, SeekFrom};
+use crate::result::ZipResult;
 use memchr::memmem::{Finder, FinderRev};
 
-use crate::result::ZipResult;
-
-type MagicSize = [u8; 4];
+const MAGIC_LENGTH: usize = 4;
+type MagicSize = [u8; MAGIC_LENGTH];
 
 pub(crate) trait FinderDirection<'a, B> {
     fn new(needle: &'a B) -> Self;
     fn reset_cursor(bounds: (u64, u64), window_size: usize) -> u64;
     fn scope_window(window: &[u8], mid_window_offset: usize) -> (&[u8], usize);
-
     fn needle(&self) -> &[u8];
     fn find(&self, haystack: &[u8]) -> Option<usize>;
     fn move_cursor(&self, cursor: u64, bounds: (u64, u64), window_size: usize) -> Option<u64>;
@@ -40,14 +40,14 @@ impl<'a> FinderDirection<'a, MagicSize> for Forward<'a> {
     }
 
     fn move_cursor(&self, cursor: u64, bounds: (u64, u64), window_size: usize) -> Option<u64> {
-        let magic_overlap = self.needle().len().saturating_sub(1) as u64;
+        let magic_overlap = MAGIC_LENGTH.saturating_sub(1) as u64;
         let next = cursor.saturating_add(window_size as u64 - magic_overlap);
 
         if next >= bounds.1 { None } else { Some(next) }
     }
 
     fn move_scope(&self, offset: usize) -> usize {
-        offset + self.needle().len()
+        offset + MAGIC_LENGTH
     }
 }
 
@@ -77,7 +77,7 @@ impl<'a> FinderDirection<'a, MagicSize> for Backwards<'a> {
     }
 
     fn move_cursor(&self, cursor: u64, bounds: (u64, u64), window_size: usize) -> Option<u64> {
-        let magic_overlap = self.needle().len().saturating_sub(1) as u64;
+        let magic_overlap = MAGIC_LENGTH.saturating_sub(1) as u64;
 
         if cursor <= bounds.0 {
             None
@@ -116,10 +116,6 @@ impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
         start_inclusive: u64,
         end_exclusive: u64,
     ) -> Self {
-        // Smaller buffer size would be unable to locate bytes.
-        // Equal buffer size would stall (the window could not be moved).
-        debug_assert!(BUFFER_SIZE >= magic_bytes.len());
-
         Self {
             buffer: [0; BUFFER_SIZE],
             finder: T::new(magic_bytes),
@@ -135,8 +131,6 @@ impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
         magic_bytes: &'a MagicSize,
         bounds: (u64, u64),
     ) -> &mut Self {
-        debug_assert!(self.buffer.len() >= magic_bytes.len());
-
         self.finder = T::new(magic_bytes);
         self.cursor = T::reset_cursor(bounds, self.buffer.len());
         self.bounds = bounds;

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -1,8 +1,8 @@
 //! Code related to the MagicFinder
 
-use std::io::{Read, Seek, SeekFrom};
 use crate::result::ZipResult;
 use memchr::memmem::{Finder, FinderRev};
+use std::io::{Read, Seek, SeekFrom};
 
 const MAGIC_LENGTH: usize = 4;
 type MagicSize = [u8; MAGIC_LENGTH];

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -223,9 +223,9 @@ pub(crate) struct OptimisticMagicFinder<Direction> {
 
 impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direction> {
     /// Create a new empty optimistic magic bytes finder.
-    pub(crate) fn new(magic_bytes: &'a MagicSize) -> Self {
+    pub(crate) fn new_empty() -> Self {
         Self {
-            inner: MagicFinder::new(magic_bytes, 0, 0),
+            inner: MagicFinder::new(&[0, 0, 0, 0], 0, 0),
             initial_guess: None,
         }
     }

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -5,7 +5,7 @@ use memchr::memmem::{Finder, FinderRev};
 use std::io::{Read, Seek, SeekFrom};
 
 const MAGIC_LENGTH: usize = 4;
-type MagicSize = [u8; MAGIC_LENGTH];
+type MagicLengthByteArray = [u8; MAGIC_LENGTH];
 
 pub(crate) trait FinderDirection<'a, B> {
     fn new(needle: &'a B) -> Self;
@@ -18,8 +18,8 @@ pub(crate) trait FinderDirection<'a, B> {
 }
 
 pub(crate) struct Forward<'a>(Finder<'a>);
-impl<'a> FinderDirection<'a, MagicSize> for Forward<'a> {
-    fn new(needle: &'a MagicSize) -> Self {
+impl<'a> FinderDirection<'a, MagicLengthByteArray> for Forward<'a> {
+    fn new(needle: &'a MagicLengthByteArray) -> Self {
         Self(Finder::new(needle))
     }
 
@@ -52,8 +52,8 @@ impl<'a> FinderDirection<'a, MagicSize> for Forward<'a> {
 }
 
 pub(crate) struct Backwards<'a>(FinderRev<'a>);
-impl<'a> FinderDirection<'a, MagicSize> for Backwards<'a> {
-    fn new(needle: &'a MagicSize) -> Self {
+impl<'a> FinderDirection<'a, MagicLengthByteArray> for Backwards<'a> {
+    fn new(needle: &'a MagicLengthByteArray) -> Self {
         Self(FinderRev::new(needle))
     }
 
@@ -110,10 +110,10 @@ pub(crate) struct MagicFinder<Direction> {
     bounds: (u64, u64),
 }
 
-impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
+impl<'a, T: FinderDirection<'a, MagicLengthByteArray>> MagicFinder<T> {
     /// Create a new magic bytes finder to look within specific bounds.
     pub(crate) fn new(
-        magic_bytes: &'a MagicSize,
+        magic_bytes: &'a MagicLengthByteArray,
         start_inclusive: u64,
         end_exclusive: u64,
     ) -> Self {
@@ -129,7 +129,7 @@ impl<'a, T: FinderDirection<'a, MagicSize>> MagicFinder<T> {
     /// Repurpose the finder for different bytes or bounds.
     pub(crate) fn repurpose(
         &mut self,
-        magic_bytes: &'a MagicSize,
+        magic_bytes: &'a MagicLengthByteArray,
         bounds: (u64, u64),
     ) -> &mut Self {
         self.finder = T::new(magic_bytes);
@@ -222,7 +222,7 @@ pub(crate) struct OptimisticMagicFinder<Direction> {
     initial_guess: Option<(u64, bool)>,
 }
 
-impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direction> {
+impl<'a, Direction: FinderDirection<'a, MagicLengthByteArray>> OptimisticMagicFinder<Direction> {
     /// Create a new empty optimistic magic bytes finder.
     pub(crate) fn new_empty() -> Self {
         Self {
@@ -234,7 +234,7 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
     /// Repurpose the finder for different bytes, bounds and initial guesses.
     pub(crate) fn repurpose(
         &mut self,
-        magic_bytes: &'a MagicSize,
+        magic_bytes: &'a MagicLengthByteArray,
         bounds: (u64, u64),
         initial_guess: Option<(u64, bool)>,
     ) -> &mut Self {
@@ -253,7 +253,7 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
         if let Some((v, mandatory)) = self.initial_guess {
             reader.seek(SeekFrom::Start(v))?;
 
-            let mut buffer: MagicSize = [0; 4];
+            let mut buffer = MagicLengthByteArray::default();
 
             // Attempt to match only if there's enough space for the needle
             if v.saturating_add(buffer.len() as u64) <= self.inner.bounds.1 {

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -101,7 +101,7 @@ const BUFFER_SIZE: usize = 2048;
 /// A utility for finding magic symbols from the end of a seekable reader.
 ///
 /// Can be repurposed to recycle the internal buffer.
-pub struct MagicFinder<Direction> {
+pub(crate) struct MagicFinder<Direction> {
     buffer: [u8; BUFFER_SIZE],
     pub(self) finder: Direction,
     cursor: u64,
@@ -217,11 +217,6 @@ pub(crate) struct OptimisticMagicFinder<Direction> {
     initial_guess: Option<(u64, bool)>,
 }
 
-/// This is a temporary restriction, to avoid heap allocation in [`Self::next_back`].
-///
-/// We only use magic bytes of size 4 at the moment.
-const STACK_BUFFER_SIZE: usize = 8;
-
 impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direction> {
     /// Create a new empty optimistic magic bytes finder.
     pub(crate) fn new(magic_bytes: &'a MagicSize) -> Self {
@@ -238,7 +233,6 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
         bounds: (u64, u64),
         initial_guess: Option<(u64, bool)>,
     ) -> &mut Self {
-        debug_assert!(magic_bytes.len() <= STACK_BUFFER_SIZE);
 
         self.inner.repurpose(magic_bytes, bounds);
         self.initial_guess = initial_guess;
@@ -252,12 +246,11 @@ impl<'a, Direction: FinderDirection<'a, MagicSize>> OptimisticMagicFinder<Direct
         if let Some((v, mandatory)) = self.initial_guess {
             reader.seek(SeekFrom::Start(v))?;
 
-            let mut buffer = [0; STACK_BUFFER_SIZE];
-            let buffer = &mut buffer[..self.inner.finder.needle().len()];
+            let mut buffer: MagicSize = [0; 4];
 
             // Attempt to match only if there's enough space for the needle
             if v.saturating_add(buffer.len() as u64) <= self.inner.bounds.1 {
-                if let Err(e) = reader.read_exact(buffer) {
+                if let Err(e) = reader.read_exact(&mut buffer) {
                     if e.kind() == std::io::ErrorKind::UnexpectedEof {
                         if mandatory {
                             return Ok(None);

--- a/src/read/magic_finder.rs
+++ b/src/read/magic_finder.rs
@@ -96,7 +96,6 @@ impl<'a> FinderDirection<'a, MagicSize> for Backwards<'a> {
     }
 }
 
-
 /// The buffer size that the finder will search
 const BUFFER_SIZE: usize = 1024;
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -892,7 +892,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 
             // Attempt to find the first CDFH
             let subfinder = subfinder
-                .get_or_insert_with(OptimisticMagicFinder::new_empty)
+                .get_or_insert_with(|| OptimisticMagicFinder::new(&CDFH_SIG_BYTES))
                 .repurpose(
                     &CDFH_SIG_BYTES,
                     // The CDFH must be before the EOCD and after the relative offset,
@@ -957,7 +957,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 
         // Attempt to find the EOCD64 with an initial guess
         let subfinder = subfinder
-            .get_or_insert_with(OptimisticMagicFinder::new_empty)
+            .get_or_insert_with(|| OptimisticMagicFinder::new(&EOCD64_SIG_BYTES))
             .repurpose(
                 &EOCD64_SIG_BYTES,
                 (locator64.end_of_central_directory_offset, locator64_offset),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -871,7 +871,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 
             // Attempt to find the first CDFH
             let subfinder = subfinder
-                .get_or_insert_with(|| OptimisticMagicFinder::new(&CDFH_SIG_BYTES))
+                .get_or_insert_with(OptimisticMagicFinder::new_empty)
                 .repurpose(
                     &CDFH_SIG_BYTES,
                     // The CDFH must be before the EOCD and after the relative offset,
@@ -936,7 +936,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 
         // Attempt to find the EOCD64 with an initial guess
         let subfinder = subfinder
-            .get_or_insert_with(|| OptimisticMagicFinder::new(&EOCD64_SIG_BYTES))
+            .get_or_insert_with(OptimisticMagicFinder::new_empty)
             .repurpose(
                 &EOCD64_SIG_BYTES,
                 (locator64.end_of_central_directory_offset, locator64_offset),


### PR DESCRIPTION
- [x] The PR title must conform to Conventional Commits


- specialize our MagicFinder to 4
- use a stack array instead of a Box<[u8]>
- reduce the BUFFER size to 1024 instead of 2048.