### PR TITLE
feat: add `compression not supported` as enum error

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -537,16 +537,11 @@ impl<R: io::BufRead> Decompressor<R> {
             CompressionMethod::Implode => Decompressor::Implode(
                 crate::legacy::implode::ImplodeDecoder::new(reader, uncompressed_size, flags),
             ),
-            #[cfg(feature = "aes-crypto")]
-            CompressionMethod::Aes => {
-                let method = CompressionMethod::Aes.serialize_to_u16();
+            method => {
+                let method = method.serialize_to_u16();
                 return Err(crate::result::ZipError::CompressionMethodNotSupported(
                     method,
                 ));
-            }
-            #[allow(deprecated)]
-            CompressionMethod::Unsupported(id) => {
-                return Err(crate::result::ZipError::CompressionMethodNotSupported(id));
             }
         })
     }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -512,8 +512,16 @@ impl<R: io::BufRead> Decompressor<R> {
             CompressionMethod::Implode => Decompressor::Implode(
                 crate::legacy::implode::ImplodeDecoder::new(reader, uncompressed_size, flags),
             ),
-            _ => {
-                return Err(crate::result::ZipError::CompressionMethodNotSupported);
+            #[cfg(feature = "aes-crypto")]
+            CompressionMethod::Aes => {
+                let method = CompressionMethod::Aes.serialize_to_u16();
+                return Err(crate::result::ZipError::CompressionMethodNotSupported(
+                    method,
+                ));
+            }
+            #[allow(deprecated)]
+            CompressionMethod::Unsupported(id) => {
+                return Err(crate::result::ZipError::CompressionMethodNotSupported(id));
             }
         })
     }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -513,9 +513,7 @@ impl<R: io::BufRead> Decompressor<R> {
                 crate::legacy::implode::ImplodeDecoder::new(reader, uncompressed_size, flags),
             ),
             _ => {
-                return Err(crate::result::ZipError::UnsupportedArchive(
-                    "Compression method not supported",
-                ));
+                return Err(crate::result::ZipError::CompressionMethodNotSupported);
             }
         })
     }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -153,6 +153,29 @@ impl CompressionMethod {
     pub const DEFAULT: Self = CompressionMethod::Stored;
 }
 impl CompressionMethod {
+    /// Convert the compression method (as `u16`) to a name
+    #[must_use]
+    pub const fn name_from_u16(val: u16) -> &'static str {
+        match val {
+            0 => "Stored",
+            1 => "Shrink",
+            2 => "Reduce(1)",
+            3 => "Reduce(2)",
+            4 => "Reduce(3)",
+            5 => "Reduce(4)",
+            6 => "Implode",
+            8 => "Deflated",
+            9 => "Deflate64",
+            12 => "Bzip2",
+            14 => "Lzma",
+            95 => "Xz",
+            93 => "Zstd",
+            98 => "Ppmd",
+            99 => "Aes",
+            _ => "Unknown",
+        }
+    }
+
     pub(crate) const fn parse_from_u16(val: u16) -> Self {
         match val {
             0 => CompressionMethod::Stored,
@@ -258,7 +281,9 @@ impl Default for CompressionMethod {
 impl fmt::Display for CompressionMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Just duplicate what the Debug format looks like, i.e, the enum key:
-        write!(f, "{self:?}")
+        let method_u16 = self.serialize_to_u16();
+        let name = Self::name_from_u16(method_u16);
+        write!(f, "{name}")
     }
 }
 

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -228,8 +228,8 @@ pub(crate) fn make_crypto_reader<'a, R: Read + ?Sized>(
 ) -> ZipResult<CryptoReader<'a, R>> {
     #[allow(deprecated)]
     {
-        if let CompressionMethod::Unsupported(_) = data.compression_method {
-            return Err(ZipError::CompressionMethodNotSupported);
+        if let CompressionMethod::Unsupported(id) = data.compression_method {
+            return Err(ZipError::CompressionMethodNotSupported(id));
         }
     }
 

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -229,9 +229,7 @@ pub(crate) fn make_crypto_reader<'a, R: Read + ?Sized>(
     #[allow(deprecated)]
     {
         if let CompressionMethod::Unsupported(_) = data.compression_method {
-            return Err(ZipError::UnsupportedArchive(
-                "Compression method not supported",
-            ));
+            return Err(ZipError::CompressionMethodNotSupported);
         }
     }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -27,6 +27,9 @@ pub enum ZipError {
 
     /// provided password is incorrect
     InvalidPassword,
+
+    /// Compression method not supported
+    CompressionMethodNotSupported,
 }
 
 impl ZipError {
@@ -52,6 +55,7 @@ impl Display for ZipError {
             Self::UnsupportedArchive(e) => write!(f, "unsupported Zip archive: {e}"),
             Self::FileNotFound => f.write_str("specified file not found in archive"),
             Self::InvalidPassword => f.write_str("provided password is incorrect"),
+            Self::CompressionMethodNotSupported => f.write_str("compression method not supported"),
         }
     }
 }
@@ -63,7 +67,8 @@ impl Error for ZipError {
             Self::InvalidArchive(_)
             | Self::UnsupportedArchive(_)
             | Self::FileNotFound
-            | Self::InvalidPassword => None,
+            | Self::InvalidPassword
+            | Self::CompressionMethodNotSupported => None,
         }
     }
 }
@@ -73,7 +78,9 @@ impl From<ZipError> for io::Error {
         let kind = match &err {
             ZipError::Io(err) => err.kind(),
             ZipError::InvalidArchive(_) => io::ErrorKind::InvalidData,
-            ZipError::UnsupportedArchive(_) => io::ErrorKind::Unsupported,
+            ZipError::UnsupportedArchive(_) | ZipError::CompressionMethodNotSupported => {
+                io::ErrorKind::Unsupported
+            }
             ZipError::FileNotFound => io::ErrorKind::NotFound,
             ZipError::InvalidPassword => io::ErrorKind::InvalidInput,
         };

--- a/src/result.rs
+++ b/src/result.rs
@@ -29,7 +29,7 @@ pub enum ZipError {
     InvalidPassword,
 
     /// Compression method not supported
-    CompressionMethodNotSupported,
+    CompressionMethodNotSupported(u16),
 }
 
 impl ZipError {
@@ -55,7 +55,9 @@ impl Display for ZipError {
             Self::UnsupportedArchive(e) => write!(f, "unsupported Zip archive: {e}"),
             Self::FileNotFound => f.write_str("specified file not found in archive"),
             Self::InvalidPassword => f.write_str("provided password is incorrect"),
-            Self::CompressionMethodNotSupported => f.write_str("compression method not supported"),
+            Self::CompressionMethodNotSupported(id) => {
+                write!(f, "compression method not supported: {id}")
+            }
         }
     }
 }
@@ -68,7 +70,7 @@ impl Error for ZipError {
             | Self::UnsupportedArchive(_)
             | Self::FileNotFound
             | Self::InvalidPassword
-            | Self::CompressionMethodNotSupported => None,
+            | Self::CompressionMethodNotSupported(_) => None,
         }
     }
 }
@@ -78,7 +80,7 @@ impl From<ZipError> for io::Error {
         let kind = match &err {
             ZipError::Io(err) => err.kind(),
             ZipError::InvalidArchive(_) => io::ErrorKind::InvalidData,
-            ZipError::UnsupportedArchive(_) | ZipError::CompressionMethodNotSupported => {
+            ZipError::UnsupportedArchive(_) | ZipError::CompressionMethodNotSupported(_) => {
                 io::ErrorKind::Unsupported
             }
             ZipError::FileNotFound => io::ErrorKind::NotFound,


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->


fix https://github.com/zip-rs/zip2/issues/773