### PR TITLE
fix: allow for `[u8]` as filename

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -91,7 +91,8 @@ pub(crate) fn make_symlink_impl<T>(
     existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     let target = Path::new(OsStr::new(&target_str));
-    let target_is_dir_from_archive = existing_files.contains_key(target_str.as_bytes()) && is_dir(target_str);
+    let target_is_dir_from_archive =
+        existing_files.contains_key(target_str.as_bytes()) && is_dir(target_str);
     let target_is_dir = if target_is_dir_from_archive {
         true
     } else if let Ok(meta) = std::fs::metadata(target) {

--- a/src/read.rs
+++ b/src/read.rs
@@ -277,7 +277,10 @@ impl<R: Read + Seek> ZipArchive<R> {
         /* Copy over file data from source archive directly. */
         io::copy(&mut limited_raw, &mut w)?;
 
-        let new_files = new_files.into_iter().map(|f| (f.0.into_boxed_bytes(), f.1)).collect();
+        let new_files = new_files
+            .into_iter()
+            .map(|f| (f.0.into_boxed_bytes(), f.1))
+            .collect();
         /* Return the files we've just written to the data stream. */
         Ok(new_files)
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -78,7 +78,7 @@ pub(crate) fn make_writable_dir_all<T: AsRef<Path>>(outpath: T) -> Result<(), Zi
 pub(crate) fn make_symlink_impl<T>(
     outpath: &Path,
     target_str: &str,
-    _existing_files: &IndexMap<Box<str>, T>,
+    _existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     std::os::unix::fs::symlink(Path::new(&target_str), outpath)?;
     Ok(())
@@ -88,7 +88,7 @@ pub(crate) fn make_symlink_impl<T>(
 pub(crate) fn make_symlink_impl<T>(
     outpath: &Path,
     target_str: &str,
-    existing_files: &IndexMap<Box<str>, T>,
+    existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     let target = Path::new(OsStr::new(&target_str));
     let target_is_dir_from_archive = existing_files.contains_key(target_str) && is_dir(target_str);
@@ -111,7 +111,7 @@ pub(crate) fn make_symlink_impl<T>(
 pub(crate) fn make_symlink<T>(
     outpath: &Path,
     target: &[u8],
-    #[cfg_attr(not(any(windows, unix)), allow(unused))] existing_files: &IndexMap<Box<str>, T>,
+    #[cfg_attr(not(any(windows, unix)), allow(unused))] existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     let Ok(target_str) = std::str::from_utf8(target) else {
         return Err(invalid!("Invalid UTF-8 as symlink target"));
@@ -123,7 +123,7 @@ pub(crate) fn make_symlink<T>(
 pub(crate) fn make_symlink<T>(
     outpath: &Path,
     target: &[u8],
-    #[cfg_attr(not(any(windows, unix)), allow(unused))] existing_files: &IndexMap<Box<str>, T>,
+    #[cfg_attr(not(any(windows, unix)), allow(unused))] existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     let Ok(_) = std::str::from_utf8(target) else {
         return Err(invalid!("Invalid UTF-8 as symlink target"));
@@ -277,10 +277,6 @@ impl<R: Read + Seek> ZipArchive<R> {
         /* Copy over file data from source archive directly. */
         io::copy(&mut limited_raw, &mut w)?;
 
-        let new_files = new_files
-            .into_iter()
-            .map(|f| (f.0.into_boxed_bytes(), f.1))
-            .collect();
         /* Return the files we've just written to the data stream. */
         Ok(new_files)
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -91,7 +91,7 @@ pub(crate) fn make_symlink_impl<T>(
     existing_files: &IndexMap<Box<[u8]>, T>,
 ) -> ZipResult<()> {
     let target = Path::new(OsStr::new(&target_str));
-    let target_is_dir_from_archive = existing_files.contains_key(target_str) && is_dir(target_str);
+    let target_is_dir_from_archive = existing_files.contains_key(target_str.as_bytes()) && is_dir(target_str);
     let target_is_dir = if target_is_dir_from_archive {
         true
     } else if let Ok(meta) = std::fs::metadata(target) {

--- a/src/read.rs
+++ b/src/read.rs
@@ -217,7 +217,7 @@ impl<R: Read + Seek> ZipArchive<R> {
     pub(crate) fn merge_contents<W: Write + Seek>(
         &mut self,
         mut w: W,
-    ) -> ZipResult<IndexMap<Box<str>, ZipFileData>> {
+    ) -> ZipResult<IndexMap<Box<[u8]>, ZipFileData>> {
         if self.shared.files.is_empty() {
             return Ok(IndexMap::new());
         }
@@ -277,6 +277,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         /* Copy over file data from source archive directly. */
         io::copy(&mut limited_raw, &mut w)?;
 
+        let new_files = new_files.into_iter().map(|f| (f.0.into_boxed_bytes(), f.1)).collect();
         /* Return the files we've just written to the data stream. */
         Ok(new_files)
     }

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -63,10 +63,10 @@ impl<R: Read> ZipStreamReader<R> {
     /// Extraction is not atomic; If an error is encountered, some of the files
     /// may be left on disk.
     pub fn extract<P: AsRef<Path>>(self, directory: P) -> ZipResult<()> {
-        struct Extractor(PathBuf, IndexMap<Box<str>, ()>);
+        struct Extractor(PathBuf, IndexMap<Box<[u8]>, ()>);
         impl ZipStreamVisitor for Extractor {
             fn visit_file<R: Read>(&mut self, file: &mut ZipFile<'_, R>) -> ZipResult<()> {
-                self.1.insert(file.name().into(), ());
+                self.1.insert(file.name_raw().into(), ());
                 let mut outpath = self.0.clone();
                 file.safe_prepare_path(&self.0, &mut outpath, None::<&(_, fn(&Path) -> bool)>)?;
 

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 /// Immutable metadata about a `ZipArchive`.
 #[derive(Debug)]
 pub struct ZipArchiveMetadata {
-    pub(crate) files: IndexMap<Box<str>, ZipFileData>,
+    pub(crate) files: IndexMap<Box<[u8]>, ZipFileData>,
     pub(crate) offset: u64,
     pub(crate) dir_start: u64,
     // This isn't yet used anywhere, but it is here for use cases in the future.
@@ -48,7 +48,7 @@ impl SharedBuilder {
     ) -> ZipArchiveMetadata {
         let mut index_map = IndexMap::with_capacity(self.files.len());
         self.files.into_iter().for_each(|file| {
-            index_map.insert(file.file_name.clone(), file);
+            index_map.insert(file.file_name_raw.clone(), file);
         });
         ZipArchiveMetadata {
             files: index_map,
@@ -90,7 +90,7 @@ pub struct ZipArchive<R> {
 
 impl<R> ZipArchive<R> {
     pub(crate) fn from_finalized_writer(
-        files: IndexMap<Box<str>, ZipFileData>,
+        files: IndexMap<Box<[u8]>, ZipFileData>,
         comment: Box<[u8]>,
         zip64_extensible_data_sector: Option<Box<[u8]>>,
         reader: R,
@@ -364,7 +364,7 @@ impl<R: Read + Seek> ZipArchive<R> {
 
     /// Returns an iterator over all the file and directory names in this archive.
     pub fn file_names(&self) -> impl Iterator<Item = &str> {
-        self.shared.files.keys().map(std::convert::AsRef::as_ref)
+        self.shared.files.values().map(|f| f.file_name.as_ref())
     }
 
     /// Returns Ok(true) if any compressed data in this archive belongs to more than one file. This
@@ -414,7 +414,7 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// Get the index of a file entry by name, if it's present.
     #[inline]
     pub fn index_for_name(&self, name: &str) -> Option<usize> {
-        self.shared.files.get_index_of(name)
+        self.shared.files.get_index_of(name.as_bytes())
     }
 
     /// Search for a file entry by path, decrypt with given password
@@ -462,7 +462,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         self.shared
             .files
             .get_index(index)
-            .map(|(name, _)| name.as_ref())
+            .map(|(_, file)| file.file_name.as_ref())
     }
 
     /// Search for a file entry by name and return a seekable object.
@@ -500,7 +500,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         name: &str,
         password: Option<&[u8]>,
     ) -> ZipResult<ZipFile<'a, R>> {
-        let Some(index) = self.shared.files.get_index_of(name) else {
+        let Some(index) = self.shared.files.get_index_of(name.as_bytes()) else {
             return Err(ZipError::FileNotFound);
         };
         self.by_index_with_options(index, ZipReadOptions::new().password(password))

--- a/src/write.rs
+++ b/src/write.rs
@@ -842,7 +842,7 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
             .collect();
         Ok(ZipWriter {
             inner: GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(readwriter)),
-            files: files,
+            files,
             stats: ZipWriterStats::default(),
             writing_to_file: false,
             comment: shared.comment,
@@ -992,15 +992,13 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
         let comment = mem::take(&mut self.comment);
         let zip64_extensible_data_sector = mem::take(&mut self.zip64_extensible_data_sector);
         let files = mem::take(&mut self.files);
-        let files: IndexMap<Box<str>, ZipFileData> = files
+        let files = files
             .into_iter()
             .map(|f| {
-                let s = String::from_utf8(f.0.into_vec())
-                    .expect("invalid UTF-8")
-                    .into_boxed_str();
-                (s, f.1)
+                let s = String::from_utf8(f.0.into_vec())?.into_boxed_str();
+                Ok((s, f.1))
             })
-            .collect();
+            .collect::<Result<_, ZipError>>()?;
         Ok(ZipArchive::from_finalized_writer(
             files,
             comment,

--- a/src/write.rs
+++ b/src/write.rs
@@ -835,7 +835,11 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     pub fn new_append_with_config(config: Config, mut readwriter: A) -> ZipResult<ZipWriter<A>> {
         readwriter.seek(SeekFrom::Start(0))?;
         let shared = ZipArchive::get_metadata(config, &mut readwriter)?;
-        let files = shared.files.into_iter().map(|f| (f.0.into_boxed_bytes(), f.1)).collect();
+        let files = shared
+            .files
+            .into_iter()
+            .map(|f| (f.0.into_boxed_bytes(), f.1))
+            .collect();
         Ok(ZipWriter {
             inner: GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(readwriter)),
             files: files,
@@ -989,14 +993,14 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
         let zip64_extensible_data_sector = mem::take(&mut self.zip64_extensible_data_sector);
         let files = mem::take(&mut self.files);
         let files: IndexMap<Box<str>, ZipFileData> = files
-    .into_iter()
-    .map(|f| {
-        let s = String::from_utf8(f.0.into_vec())
-            .expect("invalid UTF-8")
-            .into_boxed_str();
-        (s, f.1)
-    })
-    .collect();
+            .into_iter()
+            .map(|f| {
+                let s = String::from_utf8(f.0.into_vec())
+                    .expect("invalid UTF-8")
+                    .into_boxed_str();
+                (s, f.1)
+            })
+            .collect();
         Ok(ZipArchive::from_finalized_writer(
             files,
             comment,
@@ -1391,7 +1395,9 @@ impl<W: Write + Seek> ZipWriter<W> {
         if self.files.contains_key(file.file_name.as_bytes()) {
             return Err(invalid!("Duplicate filename: {}", file.file_name));
         }
-        let (index, _) = self.files.insert_full(file.file_name.as_bytes().to_vec().into_boxed_slice(), file);
+        let (index, _) = self
+            .files
+            .insert_full(file.file_name.as_bytes().to_vec().into_boxed_slice(), file);
         Ok(index)
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -172,7 +172,7 @@ pub(crate) mod zip_writer {
     /// ```
     pub struct ZipWriter<W: Write + Seek> {
         pub(super) inner: GenericZipWriter<W>,
-        pub(super) files: IndexMap<Box<str>, ZipFileData>,
+        pub(super) files: IndexMap<Box<[u8]>, ZipFileData>,
         pub(super) stats: ZipWriterStats,
         pub(super) writing_to_file: bool,
         pub(super) writing_raw: bool,
@@ -835,10 +835,10 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     pub fn new_append_with_config(config: Config, mut readwriter: A) -> ZipResult<ZipWriter<A>> {
         readwriter.seek(SeekFrom::Start(0))?;
         let shared = ZipArchive::get_metadata(config, &mut readwriter)?;
-
+        let files = shared.files.into_iter().map(|f| (f.0.into_boxed_bytes(), f.1)).collect();
         Ok(ZipWriter {
             inner: GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(readwriter)),
-            files: shared.files,
+            files: files,
             stats: ZipWriterStats::default(),
             writing_to_file: false,
             comment: shared.comment,
@@ -873,11 +873,11 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     /// widely-compatible archive compared to [`Self::shallow_copy_file`]. Does not copy alignment.
     pub fn deep_copy_file(&mut self, src_name: &str, dest_name: &str) -> ZipResult<()> {
         self.finish_file()?;
-        if src_name == dest_name || self.files.contains_key(dest_name) {
+        if src_name == dest_name || self.files.contains_key(dest_name.as_bytes()) {
             return Err(invalid!("That file already exists"));
         }
         let write_position = self.inner.try_inner_mut()?.stream_position()?;
-        let src_index = self.index_by_name(src_name)?;
+        let src_index = self.index_by_name(src_name.as_bytes())?;
         let src_data = &mut self.files[src_index];
         let src_data_start = src_data.data_start(self.inner.try_inner_mut()?)?;
         debug_assert!(src_data_start <= write_position);
@@ -894,9 +894,8 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
             .try_inner_mut()?
             .seek(SeekFrom::Start(write_position))?;
         let mut new_data = src_data.clone();
-        let dest_name_raw = dest_name.as_bytes();
+        new_data.file_name_raw = dest_name.as_bytes().into();
         new_data.file_name = dest_name.into();
-        new_data.file_name_raw = dest_name_raw.into();
         new_data.header_start = write_position;
         let extra_data_start = write_position
             + (size_of::<Magic>() + size_of::<ZipLocalEntryBlock>()) as u64
@@ -989,7 +988,15 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
         let comment = mem::take(&mut self.comment);
         let zip64_extensible_data_sector = mem::take(&mut self.zip64_extensible_data_sector);
         let files = mem::take(&mut self.files);
-
+        let files: IndexMap<Box<str>, ZipFileData> = files
+    .into_iter()
+    .map(|f| {
+        let s = String::from_utf8(f.0.into_vec())
+            .expect("invalid UTF-8")
+            .into_boxed_str();
+        (s, f.1)
+    })
+    .collect();
         Ok(ZipArchive::from_finalized_writer(
             files,
             comment,
@@ -1381,10 +1388,10 @@ impl<W: Write + Seek> ZipWriter<W> {
     }
 
     fn insert_file_data(&mut self, file: ZipFileData) -> ZipResult<usize> {
-        if self.files.contains_key(&file.file_name) {
+        if self.files.contains_key(file.file_name.as_bytes()) {
             return Err(invalid!("Duplicate filename: {}", file.file_name));
         }
-        let (index, _) = self.files.insert_full(file.file_name.clone(), file);
+        let (index, _) = self.files.insert_full(file.file_name.as_bytes().to_vec().into_boxed_slice(), file);
         Ok(index)
     }
 
@@ -1962,7 +1969,7 @@ impl<W: Write + Seek> ZipWriter<W> {
         Ok(central_start)
     }
 
-    fn index_by_name(&self, name: &str) -> ZipResult<usize> {
+    fn index_by_name(&self, name: &[u8]) -> ZipResult<usize> {
         self.files.get_index_of(name).ok_or(ZipError::FileNotFound)
     }
 
@@ -1976,7 +1983,7 @@ impl<W: Write + Seek> ZipWriter<W> {
         if src_name == dest_name {
             return Err(invalid!("Trying to copy a file to itself"));
         }
-        let src_index = self.index_by_name(src_name)?;
+        let src_index = self.index_by_name(src_name.as_bytes())?;
         let mut dest_data = self.files[src_index].clone();
         dest_data.file_name = dest_name.into();
         dest_data.file_name_raw = dest_name.as_bytes().into();

--- a/src/write.rs
+++ b/src/write.rs
@@ -835,14 +835,9 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
     pub fn new_append_with_config(config: Config, mut readwriter: A) -> ZipResult<ZipWriter<A>> {
         readwriter.seek(SeekFrom::Start(0))?;
         let shared = ZipArchive::get_metadata(config, &mut readwriter)?;
-        let files = shared
-            .files
-            .into_iter()
-            .map(|f| (f.0.into_boxed_bytes(), f.1))
-            .collect();
         Ok(ZipWriter {
             inner: GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(readwriter)),
-            files,
+            files: shared.files,
             stats: ZipWriterStats::default(),
             writing_to_file: false,
             comment: shared.comment,
@@ -992,13 +987,6 @@ impl<A: Read + Write + Seek> ZipWriter<A> {
         let comment = mem::take(&mut self.comment);
         let zip64_extensible_data_sector = mem::take(&mut self.zip64_extensible_data_sector);
         let files = mem::take(&mut self.files);
-        let files = files
-            .into_iter()
-            .map(|f| {
-                let s = String::from_utf8(f.0.into_vec())?.into_boxed_str();
-                Ok((s, f.1))
-            })
-            .collect::<Result<_, ZipError>>()?;
         Ok(ZipArchive::from_finalized_writer(
             files,
             comment,
@@ -1390,12 +1378,10 @@ impl<W: Write + Seek> ZipWriter<W> {
     }
 
     fn insert_file_data(&mut self, file: ZipFileData) -> ZipResult<usize> {
-        if self.files.contains_key(file.file_name.as_bytes()) {
+        if self.files.contains_key(&file.file_name_raw) {
             return Err(invalid!("Duplicate filename: {}", file.file_name));
         }
-        let (index, _) = self
-            .files
-            .insert_full(file.file_name.as_bytes().to_vec().into_boxed_slice(), file);
+        let (index, _) = self.files.insert_full(file.file_name_raw.clone(), file);
         Ok(index)
     }
 


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
