### PR TITLE
refactor: use and simplify is_dir

### DIFF
--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -6,9 +6,7 @@ use crate::read::{
     ZipFile, ZipFileData, ZipResult, central_header_to_zip_file_inner, make_symlink,
 };
 use crate::result::ZipError;
-use crate::spec::Magic;
-use crate::spec::Pod;
-use crate::spec::{FixedSizeBlock, ZipCentralEntryBlock, ZipLocalEntryBlock};
+use crate::spec::{FixedSizeBlock, Magic, Pod, ZipCentralEntryBlock, ZipLocalEntryBlock, is_dir};
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::io::{self, Read};
@@ -191,10 +189,7 @@ impl ZipStreamFileMetadata {
 
     /// Returns whether the file is actually a directory
     pub fn is_dir(&self) -> bool {
-        self.name()
-            .chars()
-            .next_back()
-            .is_some_and(|c| c == '/' || c == '\\')
+        is_dir(self.name())
     }
 
     /// Returns whether the file is a regular file

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -996,7 +996,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 }
 
 pub(crate) fn is_dir(filename: &str) -> bool {
-    filename.ends_with(['/', '\\'])
+matches!(filename.as_bytes().last(), Some(b'/') | Some(b'\\'))
 }
 
 #[cfg(test)]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -995,6 +995,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
     Err(parsing_error.unwrap_or(invalid!("Could not find EOCD")))
 }
 
+#[inline]
 pub(crate) fn is_dir(filename: &str) -> bool {
     filename.ends_with(['/', '\\'])
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -996,10 +996,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 }
 
 pub(crate) fn is_dir(filename: &str) -> bool {
-    filename
-        .chars()
-        .next_back()
-        .is_some_and(|c| c == '/' || c == '\\')
+    filename.ends_with(['/', '\\'])
 }
 
 #[cfg(test)]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -997,7 +997,7 @@ pub(crate) fn find_central_directory<R: Read + Seek + ?Sized>(
 
 #[inline]
 pub(crate) fn is_dir(filename: &str) -> bool {
-matches!(filename.as_bytes().last(), Some(b'/') | Some(b'\\'))
+    matches!(filename.as_bytes().last(), Some(b'/') | Some(b'\\'))
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -287,7 +287,6 @@ impl ZipFileData {
         Ok(SeekableTake::new(reader, self.compressed_size)?)
     }
 
-    #[allow(dead_code)]
     pub fn is_dir(&self) -> bool {
         is_dir(&self.file_name)
     }


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
