### PR TITLE
ci: Remove orphaned apt update from miri

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,6 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-rust-${{ hashFiles('Cargo.toml') }}
-      - run: sudo apt update
       - run: rustup toolchain add nightly-x86_64-unknown-linux-gnu
       - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
       - run: cargo +nightly miri test --target aarch64_be-unknown-linux-gnu --all --no-default-features


### PR DESCRIPTION
This apt update step is unnecessary since the workflow doesn't install or upgrade any apt packages, and it causes network requests that are hard to keep up with for StepSecurity allowlisting purposes.