### PR TITLE
refactor: Remove `ZipFileData` fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip"
-version = "8.6.0"
+version = "9.0.0"
 authors = [
     "Mathijs van de Nes <git@mathijs.vd-nes.nl>",
     "Marli Frost <marli@frost.red>",

--- a/src/read.rs
+++ b/src/read.rs
@@ -537,7 +537,6 @@ fn central_header_to_zip_file_inner<R: Read>(
     let mut result = ZipFileData {
         system,
         version_made_by,
-        is_utf8,
         compression_method: CompressionMethod::parse_from_u16(compression_method),
         compression_level: None,
         last_modified_time: DateTime::try_from_msdos(last_mod_date, last_mod_time).ok(),
@@ -705,7 +704,7 @@ pub(crate) fn parse_single_extra_field<R: Read>(
                 .unwrap_valid(&file.file_name_raw)?;
             file.file_name =
                 String::from_utf8(file.file_name_raw.clone().into_vec())?.into_boxed_str();
-            file.is_utf8 = true;
+            file.flags |= ZipFlags::LanguageEncoding.as_u16();
         }
         _ => {
             if let Err(e) = reader.read_exact(&mut vec![0u8; len as usize]) {

--- a/src/read.rs
+++ b/src/read.rs
@@ -516,9 +516,7 @@ fn central_header_to_zip_file_inner<R: Read>(
         ..
     } = block;
 
-    let encrypted = ZipFlags::matching(flags, ZipFlags::Encrypted);
     let is_utf8 = ZipFlags::matching(flags, ZipFlags::LanguageEncoding);
-    let using_data_descriptor = ZipFlags::matching(flags, ZipFlags::UsingDataDescriptor);
 
     let file_name_raw = read_variable_length_byte_field(reader, file_name_length as usize)?;
     let extra_field = read_variable_length_byte_field(reader, extra_field_length as usize)?;
@@ -539,8 +537,6 @@ fn central_header_to_zip_file_inner<R: Read>(
     let mut result = ZipFileData {
         system,
         version_made_by,
-        encrypted,
-        using_data_descriptor,
         is_utf8,
         compression_method: CompressionMethod::parse_from_u16(compression_method),
         compression_level: None,
@@ -979,7 +975,7 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
 
     /// Get if the files is encrypted or not
     pub fn encrypted(&self) -> bool {
-        self.data.encrypted
+        self.data.is_encrypted()
     }
 
     /// Get the size of the file, in bytes, in the archive

--- a/src/read/readers.rs
+++ b/src/read/readers.rs
@@ -247,7 +247,7 @@ pub(crate) fn make_crypto_reader<'a, R: Read + ?Sized>(
             vendor_version,
         },
         (Some(password), None) => {
-            let validator = if data.using_data_descriptor {
+            let validator = if data.is_using_data_descriptor() {
                 ZipCryptoValidator::InfoZipMsdosTime(
                     data.last_modified_time.map_or(0, |x| x.timepart()),
                 )

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -298,7 +298,7 @@ pub fn read_zipfile_from_stream_with_compressed_size<R: io::Read>(
     let mut result = ZipFileData::from_local_block(block, reader)?;
     result.compressed_size = compressed_size;
 
-    if result.encrypted {
+    if result.is_encrypted() {
         return Err(ZipError::UnsupportedArchive(
             "Encrypted files are not supported",
         ));

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -117,7 +117,7 @@ impl<R> ZipArchive<R> {
     pub fn decompressed_size(&self) -> Option<u128> {
         let mut total = 0u128;
         for file in self.shared.files.values() {
-            if file.using_data_descriptor {
+            if file.is_using_data_descriptor() {
                 return None;
             }
             total = total.checked_add(u128::from(file.uncompressed_size))?;
@@ -562,7 +562,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             options.password = None;
         } else {
             // Require and use the password only if the file is encrypted.
-            match (options.password, data.encrypted) {
+            match (options.password, data.is_encrypted()) {
                 (None, true) => {
                     return Err(ZipError::UnsupportedArchive(ZipError::PASSWORD_REQUIRED));
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,8 +173,6 @@ pub struct ZipFileData {
     pub version_made_by: u8,
     /// ZIP flags
     pub flags: u16,
-    /// True if `file_name` and `file_comment` are UTF8
-    pub is_utf8: bool,
     /// Compression method used to store the file
     pub compression_method: crate::compression::CompressionMethod,
     /// Compression level to store the file
@@ -459,11 +457,13 @@ impl ZipFileData {
         if encrypted {
             flags |= ZipFlags::Encrypted.as_u16();
         }
+        if std::str::from_utf8(&file_name_raw).is_ok() {
+            flags |= ZipFlags::LanguageEncoding.as_u16();
+        }
         let mut local_block = ZipFileData {
             system,
             version_made_by: DEFAULT_VERSION,
             flags,
-            is_utf8: !file_name.is_ascii(),
             compression_method,
             compression_level: options.compression_level,
             last_modified_time: Some(options.last_modified_time),
@@ -559,7 +559,6 @@ impl ZipFileData {
             system,
             version_made_by,
             flags,
-            is_utf8,
             compression_method,
             compression_level: None,
             last_modified_time: DateTime::try_from_msdos(last_mod_date, last_mod_time).ok(),
@@ -909,7 +908,6 @@ mod tests {
             system: System::Dos,
             version_made_by: 0,
             flags: 0,
-            is_utf8: true,
             compression_method: crate::compression::CompressionMethod::Stored,
             compression_level: None,
             last_modified_time: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -457,7 +457,7 @@ impl ZipFileData {
         if encrypted {
             flags |= ZipFlags::Encrypted.as_u16();
         }
-        if std::str::from_utf8(&file_name_raw).is_ok() && !file_name.is_ascii() {
+        if !file_name.is_ascii() {
             flags |= ZipFlags::LanguageEncoding.as_u16();
         }
         let mut local_block = ZipFileData {

--- a/src/types.rs
+++ b/src/types.rs
@@ -457,7 +457,7 @@ impl ZipFileData {
         if encrypted {
             flags |= ZipFlags::Encrypted.as_u16();
         }
-        if std::str::from_utf8(&file_name_raw).is_ok() {
+        if std::str::from_utf8(&file_name_raw).is_ok() && !file_name.is_ascii() {
             flags |= ZipFlags::LanguageEncoding.as_u16();
         }
         let mut local_block = ZipFileData {

--- a/src/types.rs
+++ b/src/types.rs
@@ -587,16 +587,13 @@ impl ZipFileData {
         })
     }
 
-    fn is_utf8(&self) -> bool {
-        std::str::from_utf8(&self.file_name_raw).is_ok()
-    }
-
     fn is_ascii(&self) -> bool {
         self.file_name_raw.is_ascii() && self.file_comment.is_ascii()
     }
 
     fn flags(&self) -> u16 {
-        let utf8_bit: u16 = if self.is_utf8() && !self.is_ascii() {
+        let is_utf8 = std::str::from_utf8(&self.file_name_raw).is_ok(); // file_comment is always utf8
+        let utf8_bit: u16 = if is_utf8 && !self.is_ascii() {
             ZipFlags::LanguageEncoding.as_u16()
         } else {
             0

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,6 +165,7 @@ pub const DEFAULT_VERSION: u8 = 45;
 
 /// Structure representing a ZIP file.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct ZipFileData {
     /// Compatibility of the file attribute information
     pub system: System,
@@ -172,12 +173,8 @@ pub struct ZipFileData {
     pub version_made_by: u8,
     /// ZIP flags
     pub flags: u16,
-    /// True if the file is encrypted.
-    pub encrypted: bool,
     /// True if `file_name` and `file_comment` are UTF8
     pub is_utf8: bool,
-    /// True if the file uses a data-descriptor section
-    pub using_data_descriptor: bool,
     /// Compression method used to store the file
     pub compression_method: crate::compression::CompressionMethod,
     /// Compression level to store the file
@@ -224,6 +221,16 @@ pub struct ZipFileData {
 }
 
 impl ZipFileData {
+    /// Check if the encrypted flag is set
+    pub fn is_encrypted(&self) -> bool {
+        ZipFlags::matching(self.flags, ZipFlags::Encrypted)
+    }
+
+    /// Check if the data descriptor flag is set
+    pub fn is_using_data_descriptor(&self) -> bool {
+        ZipFlags::matching(self.flags, ZipFlags::UsingDataDescriptor)
+    }
+
     /// Get the starting offset of the data of the compressed file
     pub fn data_start(&self, reader: &mut (impl Read + Seek + ?Sized)) -> ZipResult<u64> {
         match self.data_start.get() {
@@ -366,7 +373,7 @@ impl ZipFileData {
         };
         let crypto_version: u16 = if self.aes_mode.is_some() {
             51
-        } else if self.encrypted {
+        } else if self.is_encrypted() {
             20
         } else {
             10
@@ -445,15 +452,17 @@ impl ZipFileData {
                 external_attributes |= 0x01;
             }
         }
+        let mut flags = 0;
         let encrypted = options.encrypt_with.is_some();
         #[cfg(feature = "aes-crypto")]
         let encrypted = encrypted || options.aes_mode.is_some();
+        if encrypted {
+            flags |= ZipFlags::Encrypted.as_u16();
+        }
         let mut local_block = ZipFileData {
             system,
             version_made_by: DEFAULT_VERSION,
-            flags: 0,
-            encrypted,
-            using_data_descriptor: false,
+            flags,
             is_utf8: !file_name.is_ascii(),
             compression_method,
             compression_level: options.compression_level,
@@ -550,8 +559,6 @@ impl ZipFileData {
             system,
             version_made_by,
             flags,
-            encrypted,
-            using_data_descriptor,
             is_utf8,
             compression_method,
             compression_level: None,
@@ -596,13 +603,13 @@ impl ZipFileData {
             0
         };
 
-        let using_data_descriptor_bit = if self.using_data_descriptor {
+        let using_data_descriptor_bit = if self.is_using_data_descriptor() {
             ZipFlags::UsingDataDescriptor.as_u16()
         } else {
             0
         };
 
-        let encrypted_bit: u16 = if self.encrypted { 1u16 << 0 } else { 0 };
+        let encrypted_bit: u16 = if self.is_encrypted() { 1u16 << 0 } else { 0 };
 
         utf8_bit | using_data_descriptor_bit | encrypted_bit
     }
@@ -619,7 +626,7 @@ impl ZipFileData {
     }
 
     pub(crate) fn local_block(&self) -> ZipResult<ZipLocalEntryBlock> {
-        let (compressed_size, uncompressed_size) = if self.using_data_descriptor {
+        let (compressed_size, uncompressed_size) = if self.is_using_data_descriptor() {
             (0, 0)
         } else {
             (
@@ -902,8 +909,6 @@ mod tests {
             system: System::Dos,
             version_made_by: 0,
             flags: 0,
-            encrypted: false,
-            using_data_descriptor: false,
             is_utf8: true,
             compression_method: crate::compression::CompressionMethod::Stored,
             compression_level: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -587,13 +587,10 @@ impl ZipFileData {
         })
     }
 
-    fn is_ascii(&self) -> bool {
-        self.file_name_raw.is_ascii() && self.file_comment.is_ascii()
-    }
-
     fn flags(&self) -> u16 {
         let is_utf8 = std::str::from_utf8(&self.file_name_raw).is_ok(); // file_comment is always utf8
-        let utf8_bit: u16 = if is_utf8 && !self.is_ascii() {
+        let is_ascii = self.file_name_raw.is_ascii() && self.file_comment.is_ascii();
+        let utf8_bit: u16 = if is_utf8 && !is_ascii {
             ZipFlags::LanguageEncoding.as_u16()
         } else {
             0

--- a/src/write.rs
+++ b/src/write.rs
@@ -1292,7 +1292,7 @@ impl<W: Write + Seek> ZipWriter<W> {
                 return Err(invalid!("File comment must be less than 64KiB"));
             }
             if !comment.is_ascii() {
-                file.is_utf8 = true;
+                file.flags |= ZipFlags::LanguageEncoding.as_u16();
             }
             file.file_comment = comment;
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -7,6 +7,7 @@ use crate::extra_fields::UsedExtraField;
 use crate::extra_fields::Zip64ExtendedInformation;
 use crate::read::{Config, ZipArchive, ZipFile, parse_single_extra_field};
 use crate::result::{ZipError, ZipResult, invalid};
+use crate::spec::ZipFlags;
 use crate::spec::{self, FixedSizeBlock, Magic, Pod, Zip32CDEBlock, ZipLocalEntryBlock};
 use crate::types::{AesVendorVersion, MIN_VERSION, System, ZipFileData, ZipRawValues, ffi};
 use core::default::Default;
@@ -1295,8 +1296,9 @@ impl<W: Write + Seek> ZipWriter<W> {
             }
             file.file_comment = comment;
         }
-        file.using_data_descriptor =
-            !self.seek_possible || matches!(options.encrypt_with, Some(EncryptWith::ZipCrypto(..)));
+        if !self.seek_possible || matches!(options.encrypt_with, Some(EncryptWith::ZipCrypto(..))) {
+            file.flags |= ZipFlags::UsingDataDescriptor.as_u16();
+        }
         file.version_made_by = file.version_made_by.max(file.version_needed() as u8);
         file.extra_data_start = Some(header_end);
         let index = self.insert_file_data(file)?;
@@ -1411,7 +1413,7 @@ impl<W: Write + Seek> ZipWriter<W> {
             debug_assert!(file_end >= self.stats.start);
             file.compressed_size = file_end - self.stats.start;
 
-            if !file.using_data_descriptor {
+            if !file.is_using_data_descriptor() {
                 // Not using a data descriptor means the underlying writer
                 // supports seeking, so we can go back and update the AES Extra
                 // Data header to use AE1 for large files.
@@ -1426,7 +1428,7 @@ impl<W: Write + Seek> ZipWriter<W> {
                 0
             };
 
-            if file.using_data_descriptor {
+            if file.is_using_data_descriptor() {
                 file.write_data_descriptor(writer, self.auto_large_file)?;
             } else {
                 file.update_local_file_header(writer)?;


### PR DESCRIPTION
I don't really know the `is_ascii` check

https://github.com/zip-rs/zip2/commit/ea308499af60b283fc8a4eb21bcefe75e04089d3#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0

<img width="421" height="257" alt="image" src="https://github.com/user-attachments/assets/1858a137-fba4-4a88-a653-e5d5176d3e91" />
