### PR TITLE
chore: release v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/zip-rs/zip2/compare/v8.6.0...v9.0.0) - 2026-04-30
+
+### <!-- 2 -->🚜 Refactor
+
+- Remove `ZipFileData` fields ([#790](https://github.com/zip-rs/zip2/pull/790))
+- Remove useless compressed level ([#791](https://github.com/zip-rs/zip2/pull/791))
+- add non exhaustive to extra fields ([#793](https://github.com/zip-rs/zip2/pull/793))
+- remove macro export ([#792](https://github.com/zip-rs/zip2/pull/792))
+
 ## [8.6.0](https://github.com/zip-rs/zip2/compare/v8.5.1...v8.6.0) - 2026-04-25
 
 ### <!-- 0 -->🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `ZipFileData` fields ([#790](https://github.com/zip-rs/zip2/pull/790))
 - Remove useless compressed level ([#791](https://github.com/zip-rs/zip2/pull/791))
-- add non exhaustive to extra fields ([#793](https://github.com/zip-rs/zip2/pull/793))
-- remove macro export ([#792](https://github.com/zip-rs/zip2/pull/792))
+- Add non-exhaustive to extra fields ([#793](https://github.com/zip-rs/zip2/pull/793))
+- Remove macro export ([#792](https://github.com/zip-rs/zip2/pull/792))
 
 ## [8.6.0](https://github.com/zip-rs/zip2/compare/v8.5.1...v8.6.0) - 2026-04-25
 


### PR DESCRIPTION



## 🤖 New release

* `zip`: 8.6.0 -> 9.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.0.0](https://github.com/zip-rs/zip2/compare/v8.6.0...v9.0.0) - 2026-04-30

### <!-- 2 -->🚜 Refactor

- Remove `ZipFileData` fields ([#790](https://github.com/zip-rs/zip2/pull/790))
- Remove useless compressed level ([#791](https://github.com/zip-rs/zip2/pull/791))
- add non exhaustive to extra fields ([#793](https://github.com/zip-rs/zip2/pull/793))
- remove macro export ([#792](https://github.com/zip-rs/zip2/pull/792))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).