### PR TITLE
refactor!: Remove deprecated elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,6 @@ deflate-flate2 = ["_deflate-any", "dep:flate2"]
 deflate-flate2-zlib-rs = ["deflate-flate2", "flate2/zlib-rs"]
 # Pull in zopfli (write-only DEFLATE, slower than flate2 with better compression ratios)
 deflate-zopfli = ["dep:zopfli", "_deflate-any"]
-# Enables conversion to/from time::OffsetDateTime if `time` is also enabled, even though ZIP-file timestamps don't include a time zone.
-# This feature will be removed in version 9.0.0.
-deprecated-time = []
 jiff-02 = ["dep:jiff"]
 nt-time = ["dep:nt-time"]
 lzma = ["dep:lzma-rust2"]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -540,24 +540,7 @@ mod tests {
         // common year: divisible by 100 but not by 400
         assert!(DateTime::from_date_and_time(2100, 2, 29, 0, 0, 0).is_err());
     }
-
-    #[cfg(all(feature = "time", feature = "deprecated-time"))]
-    #[test]
-    fn datetime_try_from_offset_datetime() {
-        use time::macros::datetime;
-
-        use super::DateTime;
-
-        // 2018-11-17 10:38:30
-        let dt = DateTime::try_from(datetime!(2018-11-17 10:38:30 UTC)).unwrap();
-        assert_eq!(dt.year(), 2018);
-        assert_eq!(dt.month(), 11);
-        assert_eq!(dt.day(), 17);
-        assert_eq!(dt.hour(), 10);
-        assert_eq!(dt.minute(), 38);
-        assert_eq!(dt.second(), 30);
-    }
-
+    
     #[cfg(feature = "time")]
     #[test]
     fn datetime_try_from_primitive_datetime() {
@@ -594,20 +577,6 @@ mod tests {
         assert!(DateTime::try_from(datetime!(2108-01-01 00:00:00)).is_err());
     }
 
-    #[cfg(all(feature = "time", feature = "deprecated-time"))]
-    #[test]
-    fn offset_datetime_try_from_datetime() {
-        use time::OffsetDateTime;
-        use time::macros::datetime;
-
-        use super::DateTime;
-
-        // 2018-11-17 10:38:30 UTC
-        let dt =
-            OffsetDateTime::try_from(DateTime::try_from_msdos(0x4D71, 0x54CF).unwrap()).unwrap();
-        assert_eq!(dt, datetime!(2018-11-17 10:38:30 UTC));
-    }
-
     #[cfg(feature = "time")]
     #[test]
     fn primitive_datetime_try_from_datetime() {
@@ -620,25 +589,6 @@ mod tests {
         let dt =
             PrimitiveDateTime::try_from(DateTime::try_from_msdos(0x4D71, 0x54CF).unwrap()).unwrap();
         assert_eq!(dt, datetime!(2018-11-17 10:38:30));
-    }
-
-    #[cfg(all(feature = "time", feature = "deprecated-time"))]
-    #[test]
-    fn offset_datetime_try_from_bounds() {
-        use super::DateTime;
-        use time::OffsetDateTime;
-
-        // 1980-00-00 00:00:00
-        assert!(
-            OffsetDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0x0000, 0x0000) })
-                .is_err()
-        );
-
-        // 2107-15-31 31:63:62
-        assert!(
-            OffsetDateTime::try_from(unsafe { DateTime::from_msdos_unchecked(0xFFFF, 0xFFFF) })
-                .is_err()
-        );
     }
 
     #[cfg(feature = "time")]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -540,7 +540,7 @@ mod tests {
         // common year: divisible by 100 but not by 400
         assert!(DateTime::from_date_and_time(2100, 2, 29, 0, 0, 0).is_err());
     }
-    
+
     #[cfg(feature = "time")]
     #[test]
     fn datetime_try_from_primitive_datetime() {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -379,15 +379,6 @@ impl DateTime {
     }
 }
 
-#[cfg(all(feature = "time", feature = "deprecated-time"))]
-impl TryFrom<time::OffsetDateTime> for DateTime {
-    type Error = DateTimeRangeError;
-
-    fn try_from(dt: time::OffsetDateTime) -> Result<Self, Self::Error> {
-        Self::try_from(time::PrimitiveDateTime::new(dt.date(), dt.time()))
-    }
-}
-
 #[cfg(feature = "time")]
 impl TryFrom<time::PrimitiveDateTime> for DateTime {
     type Error = DateTimeRangeError;
@@ -401,15 +392,6 @@ impl TryFrom<time::PrimitiveDateTime> for DateTime {
             dt.minute(),
             dt.second(),
         )
-    }
-}
-
-#[cfg(all(feature = "time", feature = "deprecated-time"))]
-impl TryFrom<DateTime> for time::OffsetDateTime {
-    type Error = time::error::ComponentRange;
-
-    fn try_from(dt: DateTime) -> Result<Self, Self::Error> {
-        time::PrimitiveDateTime::try_from(dt).map(time::PrimitiveDateTime::assume_utc)
     }
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -421,7 +421,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                 make_symlink(&outpath, &target, &self.shared.files)?;
                 continue;
             } else if file.is_dir() {
-                crate::read::make_writable_dir_all(&outpath)?;
+                make_writable_dir_all(&outpath)?;
                 continue;
             }
             let mut outfile = fs::File::create(&outpath)?;
@@ -821,17 +821,6 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
         &self.file_name_raw
     }
 
-    /// Get the name of the file in a sanitized form. It truncates the name to the first NULL byte,
-    /// removes a leading '/' and removes '..' parts.
-    #[deprecated(
-        since = "0.5.7",
-        note = "by stripping `..`s from the path, the meaning of paths can change.
-                `mangled_name` can be used if this behaviour is desirable"
-    )]
-    pub fn sanitized_name(&self) -> PathBuf {
-        self.mangled_name()
-    }
-
     /// Rewrite the path, ignoring any path components with special meaning.
     ///
     /// - Absolute paths are made relative
@@ -924,7 +913,7 @@ impl<'a, R: Read + ?Sized> ZipFile<'a, R> {
                     Ok(meta) => meta,
                     Err(e) if e.kind() == io::ErrorKind::NotFound => {
                         if !is_last {
-                            crate::read::make_writable_dir_all(&outpath)?;
+                            make_writable_dir_all(&outpath)?;
                         }
                         break;
                     }
@@ -1101,16 +1090,16 @@ impl<R: Read + ?Sized> Read for ZipFile<'_, R> {
         self.reader.read(buf)
     }
 
-    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        self.reader.read_exact(buf)
-    }
-
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         self.reader.read_to_end(buf)
     }
 
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         self.reader.read_to_string(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.reader.read_exact(buf)
     }
 }
 

--- a/src/read/config.rs
+++ b/src/read/config.rs
@@ -17,9 +17,6 @@ pub enum ArchiveOffset {
     /// If missing, this will behave as if `None` were specified.
     #[default]
     Detect,
-    /// Use the central directory length and offset to determine the start of the archive.
-    #[deprecated(since = "2.3.0", note = "use `Detect` instead")]
-    FromCentralDirectory,
     /// Specify a fixed archive offset.
     Known(u64),
 }

--- a/src/read/config.rs
+++ b/src/read/config.rs
@@ -11,10 +11,8 @@ pub struct Config {
 /// The offset of the start of the archive from the beginning of the reader.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ArchiveOffset {
-    /// Try to detect the archive offset automatically.
-    ///
-    /// This will look at the central directory specified by `FromCentralDirectory` for a header.
-    /// If missing, this will behave as if `None` were specified.
+    /// Detect the archive offset automatically by searching for the central directory's actual
+    /// location and the location specified by the End of Central Directory (EOCD) record.
     #[default]
     Detect,
     /// Specify a fixed archive offset.

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -37,7 +37,7 @@ pub(crate) struct SharedBuilder {
     pub(super) dir_start: u64,
     // This isn't yet used anywhere, but it is here for use cases in the future.
     #[allow(dead_code)]
-    pub(super) config: super::Config,
+    pub(super) config: Config,
 }
 
 impl SharedBuilder {
@@ -345,15 +345,6 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// Get the comment of the zip archive.
     pub fn comment(&self) -> &[u8] {
         &self.shared.comment
-    }
-
-    /// Get the ZIP64 comment of the zip archive, if it is ZIP64.
-    #[deprecated(
-        note = "Zip64 comment is not part of the zip specification - see https://github.com/zip-rs/zip2/pull/747"
-    )]
-    pub fn zip64_comment(&self) -> Option<&[u8]> {
-        // no-op since deprecated
-        None
     }
 
     /// Get the ZIP64 extensible_data of the zip archive, if it is ZIP64.


### PR DESCRIPTION
<!--
We welcome your pull request, but because this crate is downloaded about 1.7 million times per month (see https://crates.io/crates/zip),
and because ZIP file processing has caused security issues in the past (see 
https://www.cvedetails.com/vulnerability-search.php?f=1&vendor=&product=zip&cweid=&cvssscoremin=&cvssscoremax=&publishdatestart=&publishdateend=&updatedatestart=&updatedateend=&cisaaddstart=&cisaaddend=&cisaduestart=&cisadueend=&page=1
for the gory details), we have some requirements that help ensure we maintain developers' and their clients' trust.
This implies some requirements that a lot of PRs don't initially meet.

This crate doesn't filter out "ZIP bombs" because extreme compression ratios and shallow file copies have legitimate uses; but
I expect the tools the crate provides for checking that extraction is safe, such as the `ZipArchive::decompressed_size` method in
https://github.com/zip-rs/zip2/blob/master/src/read.rs, to remain reliably effective. I also expect all the crate's methods to
remain panic-free, so that this crate can be used on servers without creating a denial-of-service vulnerability.

These are our requirements for PRs, in addition to the usual functionality and readability requirements:
- This codebase sometimes changes rapidly. Please rebase your branch before opening a pull request, and 
  grant @Pr0methean write access to the source branch (so I can fix later conflicts without being subject 
  to the limitations of the web UI) if EITHER of the following apply:
  - It has been at least 24 hours since you forked the repo or previously rebased the branch; or
  - 5 or more pull requests are already open at https://github.com/zip-rs/zip2/pulls. PRs are merged in the order they become
    eligible (reviewed, passing CI tests, and no conflicts with the base branch). I will attempt to fix merge
    conflicts, but this is best-effort.
- Your changes must build against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version.
- PRs must pass all the checks specified in `.github/workflows/ci.yaml`, which include:
  - Unit tests, run with `--no-default-features` AND with `--all-features` AND with the default features, each run
    against the MSRV (see README.md) AND the latest stable Rust version AND the latest nightly Rust version, on Windows, MacOS 
    AND Ubuntu (yes, that's a 3-dimensional matrix).
  - `cargo clippy --all-targets` and `cargo doc --no-deps` must pass with `--no-default-features` AND with `--all-features` 
    AND with the default features.
  - `cargo fmt --check --all` must pass.
- If the above checks force you to add a new `#[allow]` attribute, please place a comment on the same line or just above it, 
  explaining what the exception applies to and why it's needed.
- It's always better if you add a test in your merge request

Thanks in advance for submitting a bug fix or proposed feature that meets these requirements!
-->

- [x] The PR title must conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and start with one of the types specified by the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!-- This is also recommended for commit messages; but it's not required, because they'll be replaced when the PR is squash-merged. -->
