### PR TITLE
fix: Zeroize derived_key when dropped, and suppress error details that may be sensitive

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -221,10 +221,8 @@ impl<R: Read> AesReader<R> {
         }
 
         let cipher = Cipher::from_mode(self.aes_mode, decrypt_key)?;
-        let hmac = SimpleHmacReset::<Sha1>::new_from_slice(hmac_key).map_err(|e| {
-            ZipError::Io(std::io::Error::other(format!(
-                "Cannot create hmac with key: {e}"
-            )))
+        let hmac = SimpleHmacReset::<Sha1>::new_from_slice(hmac_key).map_err(|_e| {
+            ZipError::Io(std::io::Error::other("Failed to initialize HMAC"))
         })?;
 
         Ok(AesReaderValid {

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -205,7 +205,8 @@ impl<R: Read> AesReader<R> {
         // derive a key from the password and salt
         // the length depends on the aes key length
         let derived_key_len = 2 * key_length + PWD_VERIFY_LENGTH;
-        let mut derived_key: Box<[u8]> = vec![0; derived_key_len].into_boxed_slice();
+        let mut derived_key: Zeroizing<Box<[u8]>> =
+            Zeroizing::new(vec![0; derived_key_len].into_boxed_slice());
 
         // use PBKDF2 with HMAC-Sha1 to derive the key
         pbkdf2::pbkdf2::<SimpleHmacReset<Sha1>>(password, &salt, ITERATION_COUNT, &mut derived_key)

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -79,11 +79,11 @@ impl AesModeOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AesSalt {
     /// AES 128 salt
-    Aes128([u8; 8]),
+    Aes128([u8; AesMode::Aes128.salt_length()]),
     /// AES 192 salt
-    Aes192([u8; 12]),
+    Aes192([u8; AesMode::Aes192.salt_length()]),
     /// AES 256 salt
-    Aes256([u8; 16]),
+    Aes256([u8; AesMode::Aes256.salt_length()]),
 }
 
 impl AesSalt {

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -222,9 +222,8 @@ impl<R: Read> AesReader<R> {
         }
 
         let cipher = Cipher::from_mode(self.aes_mode, decrypt_key)?;
-        let hmac = SimpleHmacReset::<Sha1>::new_from_slice(hmac_key).map_err(|_e| {
-            ZipError::Io(std::io::Error::other("Failed to initialize HMAC"))
-        })?;
+        let hmac = SimpleHmacReset::<Sha1>::new_from_slice(hmac_key)
+            .map_err(|_e| ZipError::Io(std::io::Error::other("Failed to initialize HMAC")))?;
 
         Ok(AesReaderValid {
             reader: self.reader,

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -79,11 +79,11 @@ impl AesModeOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AesSalt {
     /// AES 128 salt
-    Aes128([u8; AesMode::Aes128.salt_length()]),
+    Aes128([u8; 8]),
     /// AES 192 salt
-    Aes192([u8; AesMode::Aes192.salt_length()]),
+    Aes192([u8; 12]),
     /// AES 256 salt
-    Aes256([u8; AesMode::Aes256.salt_length()]),
+    Aes256([u8; 16]),
 }
 
 impl AesSalt {


### PR DESCRIPTION
_This PR applies 3/5 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._