### PR TITLE
docs: Document safety requirements for unsafe `MaybeEncrypted::get_mut`

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -44,6 +44,15 @@ impl<W: Write> MaybeEncrypted<W> {
             MaybeEncrypted::ZipCrypto(w) => w.get_ref(),
         }
     }
+    /// Returns a mutable reference to the underlying writer.
+    ///
+    /// # Safety
+    /// The caller must preserve all invariants expected by the active wrapper
+    /// (`Unencrypted`, `Aes`, or `ZipCrypto`):
+    /// - Do not mutate the writer in a way that desynchronizes ZIP/encryption state.
+    /// - Do not seek/write behind the wrapper's back such that subsequent writes
+    ///   produce an invalid archive.
+    /// - Ensure normal `&mut` exclusivity guarantees are upheld for the returned reference.
     unsafe fn get_mut(&mut self) -> &mut W {
         match self {
             MaybeEncrypted::Unencrypted(w) => w,

--- a/src/write.rs
+++ b/src/write.rs
@@ -812,9 +812,9 @@ impl<W: Write + Seek> Write for ZipWriter<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        match self.inner.ref_mut() {
-            Some(ref mut w) => w.flush(),
-            None => Err(io::Error::new(
+        match self.inner.try_inner_mut() {
+            Ok(w) => w.flush(),
+            Err(_) => Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "flush(): ZipWriter was already closed",
             )),

--- a/src/write.rs
+++ b/src/write.rs
@@ -821,9 +821,9 @@ impl<W: Write + Seek> Write for ZipWriter<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        match self.inner.try_inner_mut() {
-            Ok(w) => w.flush(),
-            Err(_) => Err(io::Error::new(
+        match self.inner.ref_mut() {
+            Some(ref mut w) => w.flush(),
+            None => Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "flush(): ZipWriter was already closed",
             )),


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._