### PR TITLE
docs: Eliminate unnecessary clone() from an example

### DIFF
--- a/fuzz/write/src/main.rs
+++ b/fuzz/write/src/main.rs
@@ -389,7 +389,7 @@ impl Debug for FuzzTestCase<'_> {
                 "let mut initial_junk = Cursor::new(vec!{:?});\n\
                          initial_junk.seek(SeekFrom::End(0))?;\n\
                          let mut writer = ZipWriter::new(initial_junk);",
-                &self.initial_junk
+                self.initial_junk
             )?;
         }
         let _ = self.clone().execute(f, false);

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -370,7 +370,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             let end = start + file.compressed_size;
             if ranges
                 .iter()
-                .any(|range| range.start < end && start < range.end)
+                .any(|range| range.start <= end && start <= range.end)
             {
                 return Ok(true);
             }

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -370,7 +370,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             let end = start + file.compressed_size;
             if ranges
                 .iter()
-                .any(|range| range.start <= end && start <= range.end)
+                .any(|range| range.start < end && start < range.end)
             {
                 return Ok(true);
             }

--- a/src/read/zip_archive.rs
+++ b/src/read/zip_archive.rs
@@ -287,7 +287,7 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// let file_names = (0..archive.len())
     ///     .into_par_iter()
     ///     .map_init({
-    ///         let metadata = archive.metadata().clone();
+    ///         let metadata = archive.metadata();
     ///         move || {
     ///             let file = fs::File::open(FILE_NAME).unwrap();
     ///             unsafe { zip::ZipArchive::unsafe_new_with_metadata(file, metadata.clone()) }


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._