### PR TITLE
refactor!: remove deprecated method *_zip64_comment methods

### DIFF
--- a/fuzz/write/src/main.rs
+++ b/fuzz/write/src/main.rs
@@ -389,7 +389,7 @@ impl Debug for FuzzTestCase<'_> {
                 "let mut initial_junk = Cursor::new(vec!{:?});\n\
                          initial_junk.seek(SeekFrom::End(0))?;\n\
                          let mut writer = ZipWriter::new(initial_junk);",
-                &self.initial_junk
+                self.initial_junk
             )?;
         }
         let _ = self.clone().execute(f, false);

--- a/src/write.rs
+++ b/src/write.rs
@@ -461,8 +461,11 @@ impl ExtendedFileOptions {
 
 impl Debug for ExtendedFileOptions {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
-        f.write_fmt(format_args!("ExtendedFileOptions {{extra_data: vec!{:?}.into(), central_extra_data: vec!{:?}.into()}}",
-        self.extra_data, self.central_extra_data))
+        f.debug_struct("ExtendedFileOptions")
+            .field("extra_data", &self.extra_data)
+            .field("central_extra_data", &self.central_extra_data)
+            .field("file_comment", &self.file_comment)
+            .finish()
     }
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1747,13 +1747,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     where
         S: Into<String>,
     {
-        if options.permissions.is_none() {
-            options.permissions = Some(DEFAULT_DIR_PERMISSIONS);
-        }
-        *options
-            .permissions
-            .as_mut()
-            .expect("internal invariant violated: directory permissions must be set before applying directory bit") |= 0o40000;
+        options.permissions = Some(options.permissions.unwrap_or(DEFAULT_DIR_PERMISSIONS) | 0o40000);
         options.compression_method = Stored;
         options.encrypt_with = None;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1094,47 +1094,10 @@ impl<W: Write + Seek> ZipWriter<W> {
         &self.comment
     }
 
-    /// Set ZIP64 archive comment.
-    #[deprecated(
-        note = "Zip64 comment is not part of the zip specification - see https://github.com/zip-rs/zip2/pull/747"
-    )]
-    pub fn set_zip64_comment<S>(&mut self, comment: Option<S>) -> ZipResult<()>
-    where
-        S: Into<Box<str>>,
-    {
-        if let Some(com) = comment {
-            self.set_comment(com)?;
-        }
-        Ok(())
-    }
-
-    /// Set raw ZIP64 archive comment.
-    ///
-    /// This sets the raw bytes of the comment. The comment
-    /// is typically expected to be encoded in UTF-8.
-    #[deprecated(
-        note = "Zip64 comment is not part of the zip specification - see https://github.com/zip-rs/zip2/pull/747"
-    )]
-    pub fn set_raw_zip64_comment(&mut self, comment: Option<Box<[u8]>>) -> ZipResult<()> {
-        if let Some(com) = comment {
-            self.set_raw_comment(com)?;
-        }
-        Ok(())
-    }
-
     /// Get the zip64 extensible data. Use at your own risk
     /// See 4.3.14.3, 4.3.14.4, 4.4.27 and APPENDIX C of the specification
     pub fn set_raw_zip64_extensible_data_sector(&mut self, extensible_data: Box<[u8]>) {
         self.zip64_extensible_data_sector = Some(extensible_data);
-    }
-
-    /// Get ZIP64 archive comment.
-    #[deprecated(
-        note = "Zip64 comment is not part of the zip specification - see https://github.com/zip-rs/zip2/pull/747"
-    )]
-    pub fn get_zip64_comment(&self) -> Option<Result<&str, Utf8Error>> {
-        // no-op since deprecated
-        None
     }
 
     /// Get raw ZIP64 archive comment.

--- a/src/write.rs
+++ b/src/write.rs
@@ -1129,7 +1129,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     #[deprecated(
         note = "Zip64 comment is not part of the zip specification - see https://github.com/zip-rs/zip2/pull/747"
     )]
-    pub fn get_zip64_comment(&mut self) -> Option<Result<&str, Utf8Error>> {
+    pub fn get_zip64_comment(&self) -> Option<Result<&str, Utf8Error>> {
         // no-op since deprecated
         None
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1747,7 +1747,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     where
         S: Into<String>,
     {
-        options.permissions = Some(options.permissions.unwrap_or(DEFAULT_DIR_PERMISSIONS) | 0o40000);
+        *options.permissions.get_or_insert(DEFAULT_DIR_PERMISSIONS) |= 0o40000;
         options.compression_method = Stored;
         options.encrypt_with = None;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1787,7 +1787,7 @@ impl<W: Write + Seek> ZipWriter<W> {
         *options
             .permissions
             .as_mut()
-            .ok_or_else(|| std::io::Error::other("Cannot get permissions as mutable"))? |= 0o40000;
+            .expect("internal invariant violated: directory permissions must be set before applying directory bit") |= 0o40000;
         options.compression_method = Stored;
         options.encrypt_with = None;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1079,7 +1079,7 @@ impl<W: Write + Seek> ZipWriter<W> {
     }
 
     /// Get ZIP archive comment.
-    pub fn get_comment(&mut self) -> Result<&str, Utf8Error> {
+    pub fn get_comment(&self) -> Result<&str, Utf8Error> {
         from_utf8(self.get_raw_comment())
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1854,14 +1854,8 @@ impl<W: Write + Seek> ZipWriter<W> {
         target: T,
         mut options: FileOptions<'_, E>,
     ) -> ZipResult<()> {
-        if options.permissions.is_none() {
-            options.permissions = Some(0o777);
-        }
-        *options
-            .permissions
-            .as_mut()
-            .ok_or_else(|| std::io::Error::other("Cannot get permissions as mutable"))? |=
-            ffi::S_IFLNK;
+        let permissions = options.permissions.get_or_insert(0o777);
+        *permissions |= ffi::S_IFLNK;
         // The symlink target is stored as file content. And compressing the target path
         // likely wastes space. So always store.
         options.compression_method = Stored;


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings)._