### PR TITLE
docs: fix typos in tests/aes_encryption.rs

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -107,7 +107,8 @@ impl AesSalt {
     }
 
     /// Creates a new `AesSalt` with the given `mode` and `salt`.
-    /// The length of `salt` must be at least the required salt length for the given `mode`, otherwise an error is returned.
+    /// The length of `salt` must be exactly one-half the key length for the given `mode`, otherwise
+    /// an error is returned.
     ///
     /// # Errors
     /// Returns an error if the length of `salt` is too short for the given `mode`.

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -254,7 +254,7 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes128,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9].into(), // salt too long should work
+            [1, 2, 3, 4, 5, 6, 7, 8, 9].into(), // salt too long should be rejected
             Some("Salt for AES-128 must be 8 bytes long: could not convert slice to array"),
         ),
         (
@@ -269,7 +269,7 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes192,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13].into(), // salt too long should works
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13].into(), // salt too long should be rejected
             Some("Salt for AES-192 must be 12 bytes long: could not convert slice to array"),
         ),
         (
@@ -284,7 +284,8 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes256,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(), // salt too long
+            // salt too long should be rejected
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(),
             Some("Salt for AES-256 must be 16 bytes long: could not convert slice to array"),
         ),
     ] {

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -284,7 +284,7 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes256,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(), // salt too long should works
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(), // salt too long should work
             Some("Salt for AES-256 must be 16 bytes long: could not convert slice to array"),
         ),
     ] {

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -284,7 +284,7 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes256,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(), // salt too long should work
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].into(), // salt too long
             Some("Salt for AES-256 must be 16 bytes long: could not convert slice to array"),
         ),
     ] {

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -254,7 +254,7 @@ fn aes_custom_salt_for_reproducible_zip() {
         ),
         (
             AesMode::Aes128,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9].into(), // salt too long should works
+            [1, 2, 3, 4, 5, 6, 7, 8, 9].into(), // salt too long should work
             Some("Salt for AES-128 must be 8 bytes long: could not convert slice to array"),
         ),
         (


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/zip-rs/zip2/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._